### PR TITLE
Move the repo to python-jsonschema

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 # dogfood
-- repo: https://github.com/sirosen/check-jsonschema
+- repo: https://github.com/python-jsonschema/check-jsonschema
   rev: 0.13.0
   hooks:
     - id: check-github-workflows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 <!-- vendor-insert-here -->
+- The `check-jsonschema` repo has moved to a new home at
+    https://github.com/python-jsonschema/check-jsonschema
 
 ## 0.13.0
 
@@ -27,13 +29,13 @@
 
 - Add support for `--data-transform azure-pipelines` to handle compile-time
   expressions in Pipelines files. This option is applied to the azure
-  pipelines hook ([#29](https://github.com/sirosen/check-jsonschema/issues/29))
+  pipelines hook ([#29](https://github.com/python-jsonschema/check-jsonschema/issues/29))
 - Improve handing of validation errors from schemas with `anyOf` and `oneOf`
   clauses. Show the "best match" from underlying errors, and add an option
   `--show-all-validation-errors` which displays all of the underlying errors
 - Use vendored schemas in all hooks, not latest schemastore copies. This
   ensures that hook behavior is consistent
-  ([#38](https://github.com/sirosen/check-jsonschema/issues/38))
+  ([#38](https://github.com/python-jsonschema/check-jsonschema/issues/38))
 - Update vendored schemas (2022-02-12)
 - Use `requests` to make HTTP requests, and retry request failures
 
@@ -69,7 +71,7 @@
   treated as valid. To get strict python behavior (the previous behavior), use
   `--format-regex=python`. For no regex checking at all, without disabling
   other formats, use `--format-regex=disabled`.
-  resolves [#20](https://github.com/sirosen/check-jsonschema/issues/20)
+  resolves [#20](https://github.com/python-jsonschema/check-jsonschema/issues/20)
 - Add a hook for Renovate Bot config, `check-renovate`. Note that the hook does
   not support config in `package.json` (all other configuration locations are
   supported)
@@ -87,7 +89,7 @@
 - `check-jsonschema` now ships with vendored versions of the external schemas
   used for the default suite of hooks. The vendored schemas are used as a
   failover option in the event that downloading an external schema fails. This
-  resolves [#21](https://github.com/sirosen/check-jsonschema/issues/21)
+  resolves [#21](https://github.com/python-jsonschema/check-jsonschema/issues/21)
 - New CLI options, `--builtin-schema` and `--failover-builtin-schema` are
   available to access the builtin schemas. See documentation for details.
 - Use the latest version (version 4) of the `jsonschema` library. Note
@@ -129,7 +131,7 @@
   file. Defaults to failure on extensionless files.
 - Schemafiles are now passed through `os.path.expanduser`, meaning that a
   schema path of `~/myschema.json` will be expanded by check-jsonschema
-  itself ([#9](https://github.com/sirosen/check-jsonschema/issues/9))
+  itself ([#9](https://github.com/python-jsonschema/check-jsonschema/issues/9))
 - Performance enhancement for testing many files: only load the schema once
 - Added `--no-cache` option to disable schema caching
 - Change the default schema download cache directory from

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Interested in contributing to `check-jsonschema`? That's great!
 
 ## Questions, Feature Requests, Bug Reports, and Feedback...
 
-…should be reported the [Issue Tracker](https://github.com/sirosen/check-jsonschema/issues)_
+…should be reported the [Issue Tracker](https://github.com/python-jsonschema/check-jsonschema/issues)_
 
 ## Contributing Code
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/sirosen/check-jsonschema/main.svg)](https://results.pre-commit.ci/latest/github/sirosen/check-jsonschema/main)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/python-jsonschema/check-jsonschema/main.svg)](https://results.pre-commit.ci/latest/github/python-jsonschema/check-jsonschema/main)
 
 
 # check-jsonschema
@@ -54,7 +54,7 @@ You can use the schemastore github workflow schema to lint your GitHub workflow
 files. All you need to add to your `.pre-commit-config.yaml` is this:
 
 ```yaml
-- repo: https://github.com/sirosen/check-jsonschema
+- repo: https://github.com/python-jsonschema/check-jsonschema
   rev: 0.13.0
   hooks:
     - id: check-github-workflows
@@ -67,7 +67,7 @@ file or set of files. For example, to implement the GitHub workflow check
 manually, you could do this:
 
 ```yaml
-- repo: https://github.com/sirosen/check-jsonschema
+- repo: https://github.com/python-jsonschema/check-jsonschema
   rev: 0.13.0
   hooks:
     - id: check-jsonschema
@@ -81,7 +81,7 @@ And to check with the builtin schema that a GitHub workflow sets
 `timeout-minutes` on all jobs:
 
 ```yaml
-- repo: https://github.com/sirosen/check-jsonschema
+- repo: https://github.com/python-jsonschema/check-jsonschema
   rev: 0.13.0
   hooks:
     - id: check-jsonschema
@@ -239,7 +239,7 @@ In `pre-commit-config.yaml`, this can be done with `additional_dependencies`.
 For example,
 
 ```yaml
-- repo: https://github.com/sirosen/check-jsonschema
+- repo: https://github.com/python-jsonschema/check-jsonschema
   rev: 0.13.0
   hooks:
     - id: check-renovate

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ version = 0.13.0
 description = A jsonschema CLI and pre-commit hook
 long_description = file: README.md
 long_description_content_type = text/markdown
-url = https://github.com/sirosen/check-jsonschema
+url = https://github.com/python-jsonschema/check-jsonschema
 author = Stephen Rosen
 author_email = sirosen@uchicago.edu
 

--- a/tests/acceptance/test_format_regex_opts.py
+++ b/tests/acceptance/test_format_regex_opts.py
@@ -26,7 +26,7 @@ JS_REGEX_DOCUMENT = {
     "pattern": "a(?<captured>)bc",
 }
 
-# taken from https://github.com/sirosen/check-jsonschema/issues/25
+# taken from https://github.com/python-jsonschema/check-jsonschema/issues/25
 RENOVATE_DOCUMENT = {
     "regexManagers": [
         {


### PR DESCRIPTION
This is a new org created to hold check-jsonschema and the jsonschema package. As the repo has moved, various docs &c need minor tweaks to avoid extra redirects through the old name.