### PR TITLE
Use `types_or` in TOML example

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ For example,
     - id: check-jsonschema
       name: 'Check GitHub Workflows'
       files: ^mydata/
-      types: [toml]
+      types_or: [toml]
       args: ['--schemafile', 'schemas/toml-data.json']
       additional_dependencies: ['tomli']
 ```


### PR DESCRIPTION
Hi, I've found a problem in the current TOML example for pre-commit. I've done a comparison between the current example and this solution in a [separate repo](https://github.com/mondeja/test-checkjsonschema-toml):

- [With `types` the hook is not executed](https://github.com/mondeja/test-checkjsonschema-toml/runs/6706736812?check_suite_focus=true#step:4:72).
- [With `types_or` the problem is solved](https://github.com/mondeja/test-checkjsonschema-toml/runs/6706751697?check_suite_focus=true#step:4:72).

This is produced by the inheritance of `types` as a child of `types_or`. Seems that `types_or` configured at hook level takes precedence over `types` at config level. Here TOML is not a type inside YAML or JSON, so the file is not detected.

I'm not sure if could be a bug in pre-commit, is a bit counterintuitive. Also, I'm not sure why you're using `types_or` at hook level, maybe there is no a good reason and you can go with just `types`.