### PR TITLE
Fix YAML date parsing and add test

### DIFF
--- a/src/check_jsonschema/loaders/instance/yaml.py
+++ b/src/check_jsonschema/loaders/instance/yaml.py
@@ -4,6 +4,12 @@ import ruamel.yaml
 
 _yaml = ruamel.yaml.YAML(typ="safe")
 
+# ruamel.yaml parses timestamp values into datetime.datetime values which differs from
+# JSON which parses timestamps as strings. Turn off this feature.
+_yaml.constructor.yaml_constructors[
+    "tag:yaml.org,2002:timestamp"
+] = _yaml.constructor.yaml_constructors["tag:yaml.org,2002:str"]
+
 
 def _normalize(data: t.Any) -> t.Any:
     """

--- a/tests/example-files/explicit-schema/positive/complex-yaml/instance.yaml
+++ b/tests/example-files/explicit-schema/positive/complex-yaml/instance.yaml
@@ -1,0 +1,90 @@
+# Comment
+object:
+  string: "I'm a string."
+  multiline_string: |
+    I'm
+    a multiline
+    string
+
+  integer_1: 1
+  integer_2: +1
+  integer_3: -1
+
+  float_1: +1.0
+  float_2: 3.1415
+  float_3: -0.01
+  float_4: 5e+22
+  float_5: 1e06
+  float_6: -2E-2
+  float_7: 6.626e-34
+  float_8: 224_617.445_991_228
+
+  infinite_1: .inf
+  infinite_2: +.inf
+  infinite_3: -.inf
+
+  not_a_number_1: .nan
+  not_a_number_2: .NaN
+  not_a_number_3: .NAN
+
+  hexadecimal_1: 0xDEADBEEF
+  hexadecimal_2: 0xdeadbeef
+  hexadecimal_3: 0xdead_beef
+
+  octal_1: 0o01234567
+  octal_2: 0o755
+
+  binary: 0b11010110
+
+  null_1: null
+  null_2: ~
+
+  boolean_1: true
+  boolean_2: false
+  boolean_3: True
+  boolean_4: False
+  boolean_5: TRUE
+  boolean_6: FALSE
+
+  # ruamel.yaml by default converts dates to datetime objects, so check-jsonschema parses
+  # as strings
+  offset_datetime_1: 1979-05-27T07:32:00Z
+  offset_datetime_2: 1979-05-27T00:32:00-07:00
+  offset_datetime_3: 1979-05-27T00:32:00.999999-07:00
+  offset_datetime_4: '1979-05-27T07:32:00Z'
+  offset_datetime_5: '1979-05-27T00:32:00-07:00'
+  offset_datetime_6: '1979-05-27T00:32:00.999999-07:00'
+
+  datetime_1: 1979-05-27T07:32:00Z
+  datetime_2: 1979-05-27T00:32:00.999999z
+
+  local_date_1: 1979-05-27
+  local_date_2: '1979-05-27'
+
+  time_1: 07:32:00Z
+  time_2: 00:32:00.999999z
+
+  # YAML does not have a native duration type which translates to
+  # datetime.timedelta under ruamel.yaml
+  # so ISO durations can only be represented as strings
+  duration_1: "P1D"
+
+  array_1: ["a", 2, true]
+  array_2: [
+      "b",
+      3.1,
+      false,
+  ]
+
+  nested_object_1:
+    foo: "bar"
+
+  nested_object_2: { foo: "bar" }
+
+  array_of_objects_1:
+  - foo: "bar"
+  - foo: "bar"
+
+  nested_array_of_objects_1:
+    - foo: "bar"
+    - foo: "bar"

--- a/tests/example-files/explicit-schema/positive/complex-yaml/schema.json
+++ b/tests/example-files/explicit-schema/positive/complex-yaml/schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "properties": {
+    "object": {
+      "type": "object",
+      "properties": {
+        "string": { "type": "string" },
+        "multiline_string": { "type": "string" },
+        "integer_1": { "type": "integer" },
+        "integer_2": { "type": "integer" },
+        "integer_3": { "type": "integer" },
+        "float_1": { "type": "number" },
+        "float_2": { "type": "number" },
+        "float_3": { "type": "number" },
+        "float_4": { "type": "number" },
+        "float_5": { "type": "number" },
+        "float_6": { "type": "number" },
+        "float_7": { "type": "number" },
+        "float_8": { "type": "number" },
+        "infinite_1": { "type": "number" },
+        "infinite_2": { "type": "number" },
+        "infinite_3": { "type": "number" },
+        "not_a_number_1": { "type": "number" },
+        "not_a_number_2": { "type": "number" },
+        "not_a_number_3": { "type": "number" },
+        "hexadecimal_1": { "type": "number" },
+        "hexadecimal_2": { "type": "number" },
+        "hexadecimal_3": { "type": "number" },
+        "octal_1": { "type": "number" },
+        "octal_2": { "type": "number" },
+        "binary": { "type": "number" },
+        "null_1": { "type": "null" },
+        "null_2": { "type": "null" },
+        "boolean_1": { "type": "boolean" },
+        "boolean_2": { "type": "boolean" },
+        "boolean_3": { "type": "boolean" },
+        "boolean_4": { "type": "boolean" },
+        "boolean_5": { "type": "boolean" },
+        "boolean_6": { "type": "boolean" },
+        "offset_datetime_1": { "type": "string", "format": "date-time" },
+        "offset_datetime_2": { "type": "string", "format": "date-time" },
+        "offset_datetime_3": { "type": "string", "format": "date-time" },
+        "offset_datetime_4": { "type": "string", "format": "date-time" },
+        "offset_datetime_5": { "type": "string", "format": "date-time" },
+        "offset_datetime_6": { "type": "string", "format": "date-time" },
+        "datetime_1": { "type": "string", "format": "date-time" },
+        "datetime_2": { "type": "string", "format": "date-time" },
+        "local_date_1": { "type": "string", "format": "date" },
+        "local_date_2": { "type": "string", "format": "date" },
+        "time_1": { "type": "string", "format": "time" },
+        "time_2": { "type": "string", "format": "time" },
+        "duration_1": { "type": "string", "format": "duration" },
+        "array_1": { "type": "array" },
+        "array_2": { "type": "array" },
+        "nested_object_1": {
+          "type": "object",
+          "properties": { "foo": { "type": "string" } }
+        },
+        "nested_object_2": {
+          "type": "object",
+          "properties": { "foo": { "type": "string" } }
+        },
+        "array_of_objects_1": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": { "foo": { "type": "string" } }
+          }
+        },
+        "nested_array_of_objects_1": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": { "foo": { "type": "string" } }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes issue https://github.com/python-jsonschema/check-jsonschema/issues/116 by stopping ruamel.yaml from parsing dates into objects, and instead parses them as strings. Sourced from the ruamel.yaml author: https://stackoverflow.com/a/51002826