### PR TITLE
Make azure-pipelines transform more permissive

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,8 @@ Unreleased
 
 - Update vendored schemas (2022-10-12)
 - Tweak format checker usage to avoid deprecation warning from ``jsonschema``
+- The Azure Pipelines data transform is now more permissive, which should allow
+  it to handle a wider variety of pipelines files (:issue:`162`)
 
 0.18.3
 ------

--- a/src/check_jsonschema/transforms/azure_pipelines.py
+++ b/src/check_jsonschema/transforms/azure_pipelines.py
@@ -85,19 +85,39 @@ def traverse_dict(data: dict) -> dict:
         if is_expression(key):
             # WARNING -- correctness unclear
             #
-            # in the case that an expression in a dict does not map to a dict, the
-            # azure-pipelines-language server will drop it from the data:
-            # https://github.com/microsoft/azure-pipelines-language-server/blob/71b20f92874c02dfe82ad2cc2dcc7fa64996be91/language-service/src/parser/yamlParser.ts#L185
+            # "lift" any dict by moving its attributes up into the object being evaluated
             #
-            # instead, we'll raise an error
+            # e.g.
+            #    parent:
+            #      ${{ each x in xs }}:
+            #        - k: v-${{ x }}
+            #
+            # becomes
+            #
+            #    parent:
+            #      - k: v-${{ x }}
             if isinstance(newvalue, dict):
                 for add_k, add_v in newvalue.items():
                     newdata[add_k] = add_v
+            # In all other cases, drop the content from the data. This is based on the
+            # azure-pipelines-language server behavior:
+            # https://github.com/microsoft/azure-pipelines-language-server/blob/71b20f92874c02dfe82ad2cc2dcc7fa64996be91/language-service/src/parser/yamlParser.ts#L185
+            #
+            # earlier versions would raise an error here, but this caused issues with
+            # data in which expressions were mapped to simple strings
+            #
+            # e.g.
+            #
+            #    parent:
+            #      ${{ x }}: ${{ y }}
+            #
+            # which occurs naturally *after* a lifting operation, as in
+            #
+            #    parent:
+            #      ${{ each x, y in attrs }}:
+            #        ${{ x }}: ${{ y }}
             else:
-                raise AzurePipelinesDataError(
-                    "found non-object data under an expression in an object, "
-                    f"expression={key}"
-                )
+                continue
         else:
             newdata[key] = newvalue
     return newdata

--- a/tests/example-files/hooks/positive/azure-pipelines/object-defined-by-expression-map.yaml
+++ b/tests/example-files/hooks/positive/azure-pipelines/object-defined-by-expression-map.yaml
@@ -1,0 +1,15 @@
+parameters:
+  - name: env
+    default:
+      - key: FOO
+        value: foo
+      - key: BAR
+        value: bar
+
+jobs:
+  - job: echo-foo-bar
+    steps:
+      - bash: 'echo "$FOO-$BAR"'
+        env:
+          ${{ each pair in parameters.env }}:
+            ${{ pair.key }}: ${{ pair.value }}


### PR DESCRIPTION
Cases which were previously rejected are now dropped from the data when a pipeline is being transformed.
This can result in certain data transforming to an empty object, which *can* pass validation. What it can't do is provide a required or expected key based on the value which is produced by the parameter expansion.

For example, the following user-provided example:

        env:
          ${{ each pair in parameters.env }}:
            ${{ pair.key }}: ${{ pair.value }}

should now effectively "expand" to

        env: {}

---

closes #162