### PR TITLE
Check github actions schema for action.yml file only

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -50,7 +50,7 @@
   files: >
     (?x)^(
       action.(yml|yaml)|
-      \.github/actions/.*
+      \.github/actions/action.(yml|yaml)
     )$
   types: [yaml]
 


### PR DESCRIPTION
I am getting [spurious validation errors](https://github.com/Alfresco/alfresco-build-tools/actions/runs/3489491282/jobs/5839674402#step:3:191) when my custom action bundles a yml file unrelated to the action configuration itself.