### PR TITLE
Fix typos

### DIFF
--- a/src/check_jsonschema/cli.py
+++ b/src/check_jsonschema/cli.py
@@ -146,7 +146,7 @@ The '--builtin-schema' flag supports the following schema names:
     is_flag=True,
     help=(
         "Instead of validating the instances against a schema, treat each file as a "
-        "schema and validate them under ther matching metaschemas."
+        "schema and validate them under their matching metaschemas."
     ),
 )
 @click.option(

--- a/src/check_jsonschema/schema_loader/resolver.py
+++ b/src/check_jsonschema/schema_loader/resolver.py
@@ -38,5 +38,5 @@ def make_ref_resolver(
         return None
 
     base_uri = schema.get("$id", schema_uri)
-    # FIXME: temporary type-ignore beause typeshed has the type wrong
+    # FIXME: temporary type-ignore because typeshed has the type wrong
     return _CliRefResolver(base_uri, schema)  # type: ignore[arg-type]


### PR DESCRIPTION
Found via `codespell -S ./src/check_jsonschema/builtin_schemas/vendor -L shttp,testng,clude,nwe,crate,edn`