### PR TITLE
Update tox usages for v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - run: python -m pip install tox
-      - run: python -m tox -e mypy
+      - run: python -m tox run -e mypy
 
   test:
     strategy:
@@ -27,9 +27,9 @@ jobs:
       - name: install requirements
         run: python -m pip install tox
       - name: test
-        run: python -m tox -e "py{,-json5,-pyjson5,-tomli}{,-format}"
+        run: python -m tox run -m ci
       - name: twine-check
-        run: python -m tox -e twine-check
+        run: python -m tox run -e twine-check
 
   self-check:
     name: "Self-Check"

--- a/Makefile
+++ b/Makefile
@@ -3,19 +3,19 @@ PKG_VERSION=$(shell grep '^version' setup.cfg | cut -d '=' -f2 | tr -d ' ')
 .PHONY: lint test vendor-schemas generate-hooks release showvars
 lint:
 	pre-commit run -a
-	tox -e mypy
+	tox run -e mypy
 test:
-	tox
+	tox run
 vendor-schemas:
-	tox -e vendor-schemas
+	tox run -e vendor-schemas
 generate-hooks:
-	tox -e generate-hooks-config
+	tox run -e generate-hooks-config
 showvars:
 	@echo "PKG_VERSION=$(PKG_VERSION)"
 release:
 	git tag -s "$(PKG_VERSION)" -m "v$(PKG_VERSION)"
 	-git push $(shell git rev-parse --abbrev-ref @{push} | cut -d '/' -f1) refs/tags/$(PKG_VERSION)
-	tox -e publish-release
+	tox run -e publish-release
 
 .PHONY: clean
 clean:

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,12 @@
 [tox]
+# desired label:
+#   ci = py{,-json5,-pyjson5,-tomli}{,-format}"
+#
+# a tox issue will be filed to ask how this could be better supported
+# for now, 'ci' is an expanded matrix:
+labels =
+  ci = py, py-format, py-json5, py-json5-format, py-pyjson5, py-pyjson5-format, py-tomli, py-tomli-format, coverage
+
 envlist =
     cov-{clean,combine,report}
     py{311,310,39,38,37}
@@ -17,24 +25,17 @@ deps =
     format: jsonschema[format]
 commands = coverage run -m pytest {posargs}
 depends =
-    py{37,38,39,310,311}{,-json5,-pyjson5,-tomli}: cov-clean
-    cov-combine: py{37,38,39,310,311}{,-json5,-pyjson5,-tomli}
-    cov-report: cov-combine
+    py{,37,38,39,310,311}{,-json5,-pyjson5,-tomli}: coverage-clean
+    coverage: py{,37,38,39,310,311}{,-json5,-pyjson5,-tomli}
 
-[testenv:cov-clean]
+[testenv:coverage{,-clean}]
 deps = coverage
 skip_install = true
-commands = coverage erase
-
-[testenv:cov-combine]
-deps = coverage
-skip_install = true
-commands = coverage combine
-
-[testenv:cov-report]
-deps = coverage
-skip_install = true
-commands = coverage report --skip-covered
+commands_pre =
+    !clean: coverage combine
+commands =
+    clean: coverage erase
+    !clean: coverage report --skip-covered
 
 [testenv:mypy]
 deps = mypy


### PR DESCRIPTION
Can no longer pass an env list with factors as a curly-brace expression to `tox -e`, so use a label with explicitly enumerated environments instead.

Update `Makefile` and GitHub Actions usages to explicitly call `tox run`.

Unrelated to tox v4, cleanup the declaration of coverage steps to use only one tox env to run `coverage` commands.