### PR TITLE
Support multiple documents in yaml files

### DIFF
--- a/src/check_jsonschema/checker.py
+++ b/src/check_jsonschema/checker.py
@@ -67,9 +67,11 @@ class SchemaChecker:
             if isinstance(data, ParseError):
                 result.record_parse_error(path, data)
             else:
-                validator = self.get_validator(path, data)
-                for err in validator.iter_errors(data):
-                    result.record_validation_error(path, err)
+                data_list = data if isinstance(data, list) else [data]
+                for data in data_list:
+                    validator = self.get_validator(path, data)
+                    for err in validator.iter_errors(data):
+                        result.record_validation_error(path, err)
         return result
 
     def _run(self) -> None:

--- a/src/check_jsonschema/instance_loader.py
+++ b/src/check_jsonschema/instance_loader.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pathlib
+import types
 import typing as t
 
 from .parsers import ParseError, ParserSet
@@ -32,5 +33,7 @@ class InstanceLoader:
             except ParseError as err:
                 data = err
             else:
+                if isinstance(data, types.GeneratorType):
+                    data = list(data)
                 data = self._data_transform(data)
             yield (path, data)

--- a/src/check_jsonschema/parsers/__init__.py
+++ b/src/check_jsonschema/parsers/__init__.py
@@ -68,7 +68,6 @@ class ParserSet:
         self, path: pathlib.Path, default_filetype: str
     ) -> t.Callable[[t.BinaryIO], t.Any]:
         filetype = path_to_type(path, default_type=default_filetype)
-
         if filetype in self._by_tag:
             return self._by_tag[filetype]
 

--- a/src/check_jsonschema/parsers/yaml.py
+++ b/src/check_jsonschema/parsers/yaml.py
@@ -64,6 +64,15 @@ def impl2loader(
                 try:
                     data = impl.load(stream_bytes)
                 except ruamel.yaml.YAMLError as e:
+                    if isinstance(
+                        e, ruamel.yaml.composer.ComposerError
+                    ) and "expected a single document in the stream" in str(e):
+                        try:
+                            data = impl.load_all(stream_bytes)
+                        except ruamel.yaml.YAMLError as e:
+                            lasterr = e
+                        else:
+                            break
                     lasterr = e
                 else:
                     break

--- a/src/check_jsonschema/schema_loader/readers.py
+++ b/src/check_jsonschema/schema_loader/readers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import types
 import typing as t
 
 import ruamel.yaml
@@ -19,7 +20,9 @@ def _run_load_callback(schema_location: str, callback: t.Callable) -> dict:
     # only local loads can raise the YAMLError, but catch for both cases for simplicity
     except (ValueError, ruamel.yaml.error.YAMLError) as e:
         raise SchemaParseError(schema_location) from e
-    if not isinstance(schema, dict):
+    if isinstance(schema, types.GeneratorType):
+        schema = list(schema)
+    if not isinstance(schema, dict) and not isinstance(schema, list):
         raise SchemaParseError(schema_location)
     return schema
 


### PR DESCRIPTION
Quick hack to see how much work it would be ref https://github.com/python-jsonschema/check-jsonschema/issues/222

The output is a bit unintuitive atm, but could probably be improved:
```console
$ cat catalog-info.yaml
---
apiVersion: backstage.io/v1alpha1
kind: System
metadata:
  name: example-system
spec:
  owner: my-team
---
apiVersion: backstage.io/v1alpha1
kind: Component
metadata:
  name: example-service
spec:
  owner:  my-team
  system: example-system

$ check-jsonschema --schemafile "https://json.schemastore.org/catalog-info.json" -v catalog-info.yaml
Schema validation errors were encountered.
  yolo.yaml::$: {'apiVersion': 'backstage.io/v1alpha1', 'kind': 'Component', 'metadata': {'name': 'example-service'}, 'spec': {'owner': 'my-team', 'system': 'example-system'}} is not valid under any of the given schemas
  Underlying errors caused this.
  Best Match:
    $.kind: 'Component' is not one of ['API']
  All Errors:
    $.kind: 'Component' is not one of ['API']
    $.spec: 'type' is a required property
    $.spec: 'lifecycle' is a required property
    $.spec: 'definition' is a required property
    $.spec: 'type' is a required property
    $.spec: 'lifecycle' is a required property
    $.kind: 'Component' is not one of ['Domain']
    $.kind: 'Component' is not one of ['Group']
    $.spec: 'type' is a required property
    $.spec: 'children' is a required property
    $.kind: 'Component' is not one of ['Location']
    $.kind: 'Component' is not one of ['Resource']
    $.spec: 'type' is a required property
    $.kind: 'Component' is not one of ['System']
    $.apiVersion: 'backstage.io/v1alpha1' is not one of ['backstage.io/v1beta2']
    $.kind: 'Component' is not one of ['Template']
    $.spec: 'type' is a required property
    $.spec: 'steps' is a required property
    $.kind: 'Component' is not one of ['User']
    $.spec: 'memberOf' is a required property
```