### PR TITLE
Force Click to respect the color setting

### DIFF
--- a/src/check_jsonschema/reporter.py
+++ b/src/check_jsonschema/reporter.py
@@ -51,7 +51,7 @@ class TextReporter(Reporter):
         self.color = color
 
     def _echo(self, s: str, *, indent: int = 0) -> None:
-        click.echo(" " * indent + s, file=self.stream)
+        click.echo(" " * indent + s, file=self.stream, color=self.color)
 
     def _style(self, s: str, *, fg: str | None = None) -> str:
         if self.color:


### PR DESCRIPTION
By default Click strips color from output if it does not believe it is going to a terminal. This ignores the color setting used by `check-jsonschema`. We can override Click's default behavior by supplying the `color` keyword argument to `click.echo`.