### PR TITLE
Add `py.typed` marker

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,9 @@ package_dir=
 packages = find:
 include_package_data = true
 
+[options.package_data]
+check_jsonschema = py.typed
+
 [options.packages.find]
 where=src
 


### PR DESCRIPTION
This package has type hints, but they are not detected by mypy when installed as a library unless a file named `py.typed` is present.

Refer to https://peps.python.org/pep-0561/ for more information.