### PR TITLE
Fix how '--check-metaschema' builds validators

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,10 +6,13 @@ repos:
     - id: check-dependabot
     - id: check-github-workflows
     - id: check-readthedocs
-    - id: check-jsonschema
+    - id: check-metaschema
       name: Validate Vendored Schemas
-      args: ["--check-metaschema"]
       files: ^src/check_jsonschema/builtin_schemas/vendor/.*\.json$
+    - id: check-jsonschema
+      name: Validate Test Configs
+      args: ["--schemafile", "tests/example-files/config_schema.json"]
+      files: ^tests/example-files/.*/_config.yaml$
 - repo: https://github.com/pre-commit/pre-commit-hooks.git
   rev: v4.4.0
   hooks:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ Unreleased
 .. vendor-insert-here
 
 - Update vendored schemas (2023-01-18)
+- Fix a bug in which `--check-metaschema` was not building validators correctly.
+  The metaschema's schema dialect is chosen correctly now, and metaschema
+  formats are now checked by default. This can be disabled with
+  `--disable-format`.
 
 0.20.0
 ------

--- a/src/check_jsonschema/schema_loader/main.py
+++ b/src/check_jsonschema/schema_loader/main.py
@@ -74,9 +74,6 @@ class SchemaLoader(SchemaLoaderBase):
         # setup a schema reader lazily, when needed
         self._reader: LocalSchemaReader | HttpSchemaReader | None = None
 
-        # setup a location to store the validator so that it is only built once by default
-        self._validator: jsonschema.Validator | None = None
-
     @property
     def reader(self) -> LocalSchemaReader | HttpSchemaReader:
         if self._reader is None:
@@ -105,8 +102,12 @@ class SchemaLoader(SchemaLoaderBase):
     def get_schema(self) -> dict[str, t.Any]:
         return self.reader.read_schema()
 
-    def make_validator(
-        self, format_opts: FormatOptions, fill_defaults: bool
+    def get_validator(
+        self,
+        path: pathlib.Path,
+        instance_doc: dict[str, t.Any],
+        format_opts: FormatOptions,
+        fill_defaults: bool,
     ) -> jsonschema.Validator:
         schema_uri = self.get_schema_ref_base()
         schema = self.get_schema()
@@ -137,16 +138,6 @@ class SchemaLoader(SchemaLoaderBase):
             format_checker=format_checker,
         )
         return t.cast(jsonschema.Validator, validator)
-
-    def get_validator(
-        self,
-        path: pathlib.Path,
-        instance_doc: dict[str, t.Any],
-        format_opts: FormatOptions,
-        fill_defaults: bool,
-    ) -> jsonschema.Validator:
-        self._validator = self.make_validator(format_opts, fill_defaults)
-        return self._validator
 
 
 class BuiltinSchemaLoader(SchemaLoader):

--- a/src/check_jsonschema/schema_loader/main.py
+++ b/src/check_jsonschema/schema_loader/main.py
@@ -159,5 +159,16 @@ class MetaSchemaLoader(SchemaLoaderBase):
         format_opts: FormatOptions,
         fill_defaults: bool,
     ) -> jsonschema.Validator:
-        validator = jsonschema.validators.validator_for(instance_doc)
-        return t.cast(jsonschema.Validator, validator(validator.META_SCHEMA))
+        schema_validator = jsonschema.validators.validator_for(instance_doc)
+        meta_validator_class = jsonschema.validators.validator_for(
+            schema_validator.META_SCHEMA, default=schema_validator
+        )
+
+        # format checker (which may be None)
+        meta_schema_dialect = schema_validator.META_SCHEMA.get("$schema")
+        format_checker = make_format_checker(format_opts, meta_schema_dialect)
+
+        meta_validator = meta_validator_class(
+            schema_validator.META_SCHEMA, format_checker=format_checker
+        )
+        return meta_validator

--- a/tests/acceptance/test_example_files.py
+++ b/tests/acceptance/test_example_files.py
@@ -36,7 +36,7 @@ def _build_hook_cases(category):
         example_dir = EXAMPLE_HOOK_FILES / category / hookid
         if example_dir.exists():
             for example in example_dir.iterdir():
-                res[str(example.relative_to(EXAMPLE_HOOK_FILES))] = hookid
+                res[str(example.relative_to(EXAMPLE_HOOK_FILES / category))] = hookid
     return res
 
 
@@ -64,7 +64,9 @@ def test_hook_positive_examples(case_name, run_line):
     _check_case_skip(case_name)
 
     hook_id = POSITIVE_HOOK_CASES[case_name]
-    ret = run_line(HOOK_CONFIG[hook_id] + [str(EXAMPLE_HOOK_FILES / case_name)])
+    ret = run_line(
+        HOOK_CONFIG[hook_id] + [str(EXAMPLE_HOOK_FILES / "positive" / case_name)]
+    )
     assert ret.exit_code == 0
 
 
@@ -72,7 +74,9 @@ def test_hook_positive_examples(case_name, run_line):
 def test_hook_negative_examples(case_name, run_line):
     _check_case_skip(case_name)
     hook_id = NEGATIVE_HOOK_CASES[case_name]
-    ret = run_line(HOOK_CONFIG[hook_id] + [str(EXAMPLE_HOOK_FILES / case_name)])
+    ret = run_line(
+        HOOK_CONFIG[hook_id] + [str(EXAMPLE_HOOK_FILES / "negative" / case_name)]
+    )
     assert ret.exit_code == 1
 
 

--- a/tests/example-files/config_schema.json
+++ b/tests/example-files/config_schema.json
@@ -1,0 +1,37 @@
+{
+  "$comment": "An internal schema used to check the testsuite _config.yaml files.",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "spec": {
+      "type": "object",
+      "properties": {
+        "requires_packages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "add_args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "type": "object",
+  "properties": {
+    "files": {
+      "type": "object",
+      "patternProperties": {
+        "^.+\\.(json|yml|yaml|json5|toml)$": {
+          "$ref": "#/$defs/spec"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/example-files/hooks/negative/metaschema/2020_invalid_format_value.json
+++ b/tests/example-files/hooks/negative/metaschema/2020_invalid_format_value.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Meta-schema defining a ref with invalid URI reference",
+  "$defs": {
+    "prop<(str|list)>": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": true
+        }
+      ]
+    },
+    "anchorString": {
+      "type": "string",
+      "pattern": "^[A-Za-z_][-A-Za-z0-9._]*$"
+    },
+    "uriString": {
+      "type": "string",
+      "format": "uri"
+    },
+    "uriReferenceString": {
+      "type": "string",
+      "format": "uri-reference"
+    },
+    "original2020metaschema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$vocabulary": {
+        "https://json-schema.org/draft/2020-12/vocab/core": true
+      },
+      "$dynamicAnchor": "meta",
+      "title": "Core vocabulary meta-schema",
+      "type": [
+        "object",
+        "boolean"
+      ],
+      "properties": {
+        "$id": {
+          "$ref": "#/$defs/uriReferenceString",
+          "$comment": "Non-empty fragments not allowed.",
+          "pattern": "^[^#]*#?$"
+        },
+        "$schema": {
+          "$ref": "#/$defs/uriString"
+        },
+        "$ref": {
+          "$ref": "#/$defs/uriReferenceString"
+        },
+        "$anchor": {
+          "$ref": "#/$defs/anchorString"
+        },
+        "$dynamicRef": {
+          "$ref": "#/$defs/uriReferenceString"
+        },
+        "$dynamicAnchor": {
+          "$ref": "#/$defs/anchorString"
+        },
+        "$vocabulary": {
+          "type": "object",
+          "propertyNames": {
+            "$ref": "#/$defs/uriString"
+          },
+          "additionalProperties": {
+            "type": "boolean"
+          }
+        },
+        "$comment": {
+          "type": "string"
+        },
+        "$defs": {
+          "type": "object",
+          "additionalProperties": {
+            "$dynamicRef": "#meta"
+          }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/$defs/original2020metaschema"
+    },
+    {
+      "properties": {
+        "title": {
+          "$ref": "#/$defs/prop<(str|list)>"
+        }
+      }
+    }
+  ]
+}

--- a/tests/example-files/hooks/negative/metaschema/_config.yaml
+++ b/tests/example-files/hooks/negative/metaschema/_config.yaml
@@ -1,0 +1,4 @@
+files:
+  2020_invalid_format_value.json:
+    requires_packages:
+      - rfc3987

--- a/tests/example-files/hooks/positive/metaschema/2020_invalid_format_value.json
+++ b/tests/example-files/hooks/positive/metaschema/2020_invalid_format_value.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Meta-schema defining a ref with invalid URI reference",
+  "$defs": {
+    "prop<(str|list)>": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": true
+        }
+      ]
+    },
+    "anchorString": {
+      "type": "string",
+      "pattern": "^[A-Za-z_][-A-Za-z0-9._]*$"
+    },
+    "uriString": {
+      "type": "string",
+      "format": "uri"
+    },
+    "uriReferenceString": {
+      "type": "string",
+      "format": "uri-reference"
+    },
+    "original2020metaschema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$vocabulary": {
+        "https://json-schema.org/draft/2020-12/vocab/core": true
+      },
+      "$dynamicAnchor": "meta",
+      "title": "Core vocabulary meta-schema",
+      "type": [
+        "object",
+        "boolean"
+      ],
+      "properties": {
+        "$id": {
+          "$ref": "#/$defs/uriReferenceString",
+          "$comment": "Non-empty fragments not allowed.",
+          "pattern": "^[^#]*#?$"
+        },
+        "$schema": {
+          "$ref": "#/$defs/uriString"
+        },
+        "$ref": {
+          "$ref": "#/$defs/uriReferenceString"
+        },
+        "$anchor": {
+          "$ref": "#/$defs/anchorString"
+        },
+        "$dynamicRef": {
+          "$ref": "#/$defs/uriReferenceString"
+        },
+        "$dynamicAnchor": {
+          "$ref": "#/$defs/anchorString"
+        },
+        "$vocabulary": {
+          "type": "object",
+          "propertyNames": {
+            "$ref": "#/$defs/uriString"
+          },
+          "additionalProperties": {
+            "type": "boolean"
+          }
+        },
+        "$comment": {
+          "type": "string"
+        },
+        "$defs": {
+          "type": "object",
+          "additionalProperties": {
+            "$dynamicRef": "#meta"
+          }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/$defs/original2020metaschema"
+    },
+    {
+      "properties": {
+        "title": {
+          "$ref": "#/$defs/prop<(str|list)>"
+        }
+      }
+    }
+  ]
+}

--- a/tests/example-files/hooks/positive/metaschema/_config.yaml
+++ b/tests/example-files/hooks/positive/metaschema/_config.yaml
@@ -1,0 +1,3 @@
+files:
+  2020_invalid_format_value.json:
+    add_args: ["--disable-format"]


### PR DESCRIPTION
This should resolve the primary bug in #220. I'll need to file a follow-up for the additional feature work related to that use-case.