### PR TITLE
Fix resolution of format checker classes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Unreleased
   The metaschema's schema dialect is chosen correctly now, and metaschema
   formats are now checked by default. This can be disabled with
   `--disable-format`.
+- Fix the resolution of `$schema` dialect to format checker classes
 
 0.20.0
 ------


### PR DESCRIPTION
Use `validator_for` on a dummy schema document to get the relevant validator class. This removes maintenance of a dialect table from check-jsonschema and fixes some of the dialects being declared incorrectly.