### PR TITLE
Batch parameter leads to azure pipelines check failure

### DIFF
--- a/tests/example-files/hooks/positive/azure-pipelines/marshmallow.yaml
+++ b/tests/example-files/hooks/positive/azure-pipelines/marshmallow.yaml
@@ -1,6 +1,7 @@
 # config pulled from marshmallow-code/marshmallow 2022-01
 
 trigger:
+  batch: true
   branches:
     include: [dev, 2.x-line, test-me-*]
   tags:


### PR DESCRIPTION
This file fails locally for me, but is definitely supported. See https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/trigger?view=azure-pipelines#trigger-batch-branches-paths-tags.

```
> check-jsonschema --builtin-schema vendor.azure-pipelines --data-transform azure-pipelines marshmallow.yaml  
```

```
Schema validation errors were encountered.
  marshmallow.yaml::$: {'trigger': {'batch': True, 'branches': {'include': ['dev', '2.x-line', 'test-me-*']}, 'tags': {'include': ['*']}}, 'resources': {'repositories': [{'repository': 'sloria', 'type': 'github', 'endpoint': 'github', 'name': 'sloria/azure-pipeline-templates', 'ref': 'refs/heads/sloria'}]}, 'jobs': [{'template': 'job--python-tox.yml@sloria', 'parameters': {'toxenvs': ['lint', 'py37', 'py310'], 'os': 'linux'}}, {'template': 'job--pypi-release.yml@sloria', 'parameters': {'dependsOn': ['tox_linux']}}]} is not valid under any of the given schemas
  Underlying errors caused this.
  Best Match:
    $: {'trigger': {'batch': True, 'branches': {'include': ['dev', '2.x-line', 'test-me-*']}, 'tags': {'include': ['*']}}, 'resources': {'repositories': [{'repository': 'sloria', 'type': 'github', 'endpoint': 'github', 'name': 'sloria/azure-pipeline-templates', 'ref': 'refs/heads/sloria'}]}, 'jobs': [{'template': 'job--python-tox.yml@sloria', 'parameters': {'toxenvs': ['lint', 'py37', 'py310'], 'os': 'linux'}}, {'template': 'job--pypi-release.yml@sloria', 'parameters': {'dependsOn': ['tox_linux']}}]} is not of type 'string'
```

Using 0.21.0 installed via pipx on Windows.