### PR TITLE
Add support for dependabot.yaml file also

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -53,7 +53,7 @@
   description: 'Validate Dependabot Config (v2) against the schema provided by SchemaStore'
   entry: check-jsonschema --builtin-schema vendor.dependabot
   language: python
-  files: ^\.github/dependabot.yml$
+  files: ^\.github/dependabot.(yml|yaml)$
   types: [yaml]
 
 - id: check-github-actions

--- a/tests/acceptance/test_hook_file_matches.py
+++ b/tests/acceptance/test_hook_file_matches.py
@@ -64,8 +64,8 @@ _HOOKID_PATH_MAP = {
         ),
     },
     "check-dependabot": {
-        "good": (".github/dependabot.yml",),
-        "bad": (".github/dependabot.yaml", ".dependabot.yml"),
+        "good": (".github/dependabot.yml", ".github/dependabot.yaml"),
+        "bad": (".dependabot.yaml", ".dependabot.yml"),
     },
     "check-github-actions": {
         "good": (


### PR DESCRIPTION
Today check-dependabot only supports dependabot.yml files. Dependabot supports .dependabot.yaml files also.