### PR TITLE
Fix the jsonschema lower bound in setup.cfg

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ Unreleased
 - Update vendored schemas (2023-02-18)
 - The ``check-dependabot`` hook now also supports ``.github/dependabot.yaml``
   Thanks :user:`noorul`!
+- Fix a mistake in the dependency bound for ``jsonschema``, which was intended
+  to change in v0.21.0
 
 0.21.0
 ------

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ python_requires = >=3.7
 install_requires =
     importlib-resources>=1.4.0;python_version<"3.9"
     ruamel.yaml==0.17.21
-    jsonschema>=4,<5.0
+    jsonschema>=4.5.1,<5.0
     requests<3.0
     click>=8,<9
 package_dir=


### PR DESCRIPTION
This was supposed to update in v0.21.0 , but this didn't happen correctly. The changeset updated the mindeps test and other locations, but the change to setup.cfg itself was never committed.