### PR TITLE
Fix the handling of bad Last-Modified headers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ Unreleased
 ----------
 
 .. vendor-insert-here
+- Fix the handling of malformed and missing ``Last-Modified`` headers in the
+  caching downloader. Thanks :user:`balihb`! (:issue:`275`)
 
 0.23.1
 ------

--- a/src/check_jsonschema/cachedownloader.py
+++ b/src/check_jsonschema/cachedownloader.py
@@ -17,7 +17,6 @@ class FailedDownloadError(Exception):
 
 
 class CacheDownloader:
-    _LASTMOD_DEFAULT = "Sun, 01 Jan 1970 00:00:01 GMT"
     _LASTMOD_FMT = "%a, %d %b %Y %H:%M:%S %Z"
 
     # changed in v0.5.0
@@ -83,12 +82,15 @@ class CacheDownloader:
             raise FailedDownloadError("encountered error during download") from e
 
     def _lastmod_from_response(self, response: requests.Response) -> float:
-        return time.mktime(
-            time.strptime(
-                response.headers.get("last-modified", self._LASTMOD_DEFAULT),
-                self._LASTMOD_FMT,
+        try:
+            return time.mktime(
+                time.strptime(response.headers["last-modified"], self._LASTMOD_FMT)
             )
-        )
+        # OverflowError: time outside of platform-specific bounds
+        # ValueError: malformed/unparseable
+        # LookupError: no such header
+        except (OverflowError, ValueError, LookupError):
+            return 0.0
 
     def _cache_hit(self, cachefile: str, response: requests.Response) -> bool:
         # no file? miss


### PR DESCRIPTION
Originally found via an OverflowError on some Windows usage where the default Last-Modified header was used, there are several issues which were not handled correctly by the downloader.
1. OverflowError: a last mod date outside of `mktime`'s supported range causes this
2. ValueError: a malformed header causes `strptime` to fail
3. LookupError/KeyError: the header is missing

(3) was previously handled by falling back to a default time which was then strptime parsed. This is now caught as a LookupError and handled with the fixed default of `0.0` used for all of these bad-parse cases. The semantics are the same, but the implementation is simpler and more uniform.