### PR TITLE
Add support for remote YAML/TOML/JSON5 schemas

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,9 @@ Unreleased
   non-JSON format supported by `check-jsonschema`. The file type is inferred
   only from the file extension in these cases and defaults to JSON if there is
   no recognizable extension.
+- Remote schemafiles (http/s) now support YAML, TOML, and JSON5 formats, if the
+  URL ends with the appropriate extension and the matching parser is available.
+  Extensionless URLs are treated as JSON.
 
 0.23.3
 ------

--- a/src/check_jsonschema/checker.py
+++ b/src/check_jsonschema/checker.py
@@ -48,7 +48,7 @@ class SchemaChecker:
 
     def get_validator(
         self, path: pathlib.Path, doc: dict[str, t.Any]
-    ) -> jsonschema.Validator:
+    ) -> jsonschema.protocols.Validator:
         try:
             return self._schema_loader.get_validator(
                 path, doc, self._format_opts, self._fill_defaults

--- a/src/check_jsonschema/schema_loader/main.py
+++ b/src/check_jsonschema/schema_loader/main.py
@@ -17,7 +17,7 @@ from .resolver import make_reference_registry
 
 
 def _extend_with_default(
-    validator_class: type[jsonschema.Validator],
+    validator_class: type[jsonschema.protocols.Validator],
 ) -> type[jsonschema.Validator]:
     validate_properties = validator_class.VALIDATORS["properties"]
 
@@ -51,7 +51,7 @@ class SchemaLoaderBase:
         instance_doc: dict[str, t.Any],
         format_opts: FormatOptions,
         fill_defaults: bool,
-    ) -> jsonschema.Validator:
+    ) -> jsonschema.protocols.Validator:
         raise NotImplementedError
 
 
@@ -112,7 +112,7 @@ class SchemaLoader(SchemaLoaderBase):
         instance_doc: dict[str, t.Any],
         format_opts: FormatOptions,
         fill_defaults: bool,
-    ) -> jsonschema.Validator:
+    ) -> jsonschema.protocols.Validator:
         retrieval_uri = self.get_schema_retrieval_uri()
         schema = self.get_schema()
 
@@ -141,7 +141,7 @@ class SchemaLoader(SchemaLoaderBase):
             registry=reference_registry,
             format_checker=format_checker,
         )
-        return t.cast(jsonschema.Validator, validator)
+        return t.cast(jsonschema.protocols.Validator, validator)
 
 
 class BuiltinSchemaLoader(SchemaLoader):
@@ -163,7 +163,7 @@ class MetaSchemaLoader(SchemaLoaderBase):
         instance_doc: dict[str, t.Any],
         format_opts: FormatOptions,
         fill_defaults: bool,
-    ) -> jsonschema.Validator:
+    ) -> jsonschema.protocols.Validator:
         schema_validator = jsonschema.validators.validator_for(instance_doc)
         meta_validator_class = jsonschema.validators.validator_for(
             schema_validator.META_SCHEMA, default=schema_validator

--- a/tests/unit/test_schema_loader.py
+++ b/tests/unit/test_schema_loader.py
@@ -2,6 +2,7 @@ import os
 import pathlib
 
 import pytest
+import responses
 
 from check_jsonschema.schema_loader import SchemaLoader, SchemaParseError
 from check_jsonschema.schema_loader.readers import HttpSchemaReader, LocalSchemaReader
@@ -40,12 +41,12 @@ def test_schemaloader_path_handling_relative_local_path(in_tmp_dir, filename):
     [
         "schema.yaml",
         "schema.yml",
+        "https://foo.example.com/schema.yaml",
+        "https://foo.example.com/schema.yml",
     ],
 )
-def test_schemaloader_local_yaml_data(tmp_path, filename):
-    f = tmp_path / filename
-    f.write_text(
-        """
+def test_schemaloader_yaml_data(tmp_path, filename):
+    schema_text = """
 ---
 "$schema": https://json-schema.org/draft/2020-12/schema
 type: object
@@ -60,8 +61,14 @@ properties:
       c:
         type: string
 """
-    )
-    sl = SchemaLoader(str(f))
+    if filename.startswith("http"):
+        responses.add("GET", filename, body=schema_text)
+        path = filename
+    else:
+        f = tmp_path / filename
+        f.write_text(schema_text)
+        path = str(f)
+    sl = SchemaLoader(path)
     schema = sl.get_schema()
     assert schema == {
         "$schema": "https://json-schema.org/draft/2020-12/schema",


### PR DESCRIPTION
Also fix a new deprecation warning about the import path for `jsonschema.protocols.Validator`.

Fixes #294