### PR TITLE
Fix two issues with newer ref resolution

### DIFF
--- a/src/check_jsonschema/parsers/__init__.py
+++ b/src/check_jsonschema/parsers/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import json
 import pathlib
 import typing as t
@@ -83,10 +84,12 @@ class ParserSet:
         )
 
     def parse_data_with_path(
-        self, data: t.BinaryIO, path: pathlib.Path | str, default_filetype: str
+        self, data: t.BinaryIO | bytes, path: pathlib.Path | str, default_filetype: str
     ) -> t.Any:
         loadfunc = self.get(path, default_filetype)
         try:
+            if isinstance(data, bytes):
+                data = io.BytesIO(data)
             return loadfunc(data)
         except LOADING_FAILURE_ERROR_TYPES as e:
             raise FailedFileLoadError(f"Failed to parse {path}") from e


### PR DESCRIPTION
- Add a cache for remote lookups
- Use `.content`, not `.raw`, on the response object

`.raw` does not expose the same binary data as `.content` in all cases. e.g. gzipped content is exposed verbatim.