### PR TITLE
Introduce 'best deep match' heuristic

### DIFF
--- a/tests/unit/test_reporters.py
+++ b/tests/unit/test_reporters.py
@@ -130,6 +130,11 @@ def test_text_print_validation_error_nested(capsys, verbosity):
         assert "$.foo: {} is not of type 'string'" in captured.out
         assert "$.bar: {'baz': 'buzz'} is not of type 'string'" in captured.out
         assert "$.bar.baz: 'buzz' is not of type 'integer'" in captured.out
+    else:
+        assert (
+            "4 other errors were produced. Use '--verbose' to see all errors."
+            in captured.out
+        )
 
 
 @pytest.mark.parametrize("pretty_json", (True, False))
@@ -187,6 +192,7 @@ def test_json_format_validation_error_nested(capsys, pretty_json, verbosity):
     assert len(data["errors"]) == 1
     assert "is not valid under any of the given schemas" in data["errors"][0]["message"]
     assert data["errors"][0]["has_sub_errors"]
+    assert data["errors"][0]["num_sub_errors"] == 5
 
     # stop here unless 'verbosity>=2'
     if verbosity < 2:


### PR DESCRIPTION
And also print a small hint that `--verbose` should be used to try to see all errors.

Tests are just tweaked a little to catch this in the output, but a sample of the new rendering...
![image](https://github.com/python-jsonschema/check-jsonschema/assets/1300022/76e8771c-f9ad-42f2-9303-0cd2ed99915e)

Hopefully, this can guide people towards `--verbose` more often when they need it, and the "best deep match" might surface better things for certain schemas. The whole space of guessing which error to show is kind of dicey though -- I tried various priorities for different validators and found that it _always_ depends on how the schema was written.