### PR TITLE
Use regress and remove 'disabled' regex format

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,10 @@ Unreleased
 ----------
 
 .. vendor-insert-here
+- The regex format check has been improved to support ECMAScript regexes by
+  default. (:issue:`302`)
+- The ``--format-regex disabled`` option has been removed. Users should use
+  ``--disable-formats regex`` if they wish to disable regex format checking.
 
 0.25.0
 ------
@@ -71,7 +75,7 @@ Unreleased
 - A new option, ``--disable-formats`` replaces and enhances the
   ``--disable-format`` flag. ``--disable-formats`` takes a format to disable
   and may be passed multiple times, allowing users to opt out of any specific
-  format checks. ``--disable-format "*"`` can be used to disable all format
+  format checks. ``--disable-formats "*"`` can be used to disable all format
   checking. ``--disable-format`` is still supported, but is deprecated and
   emits a warning.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -198,13 +198,10 @@ follows:
 
    * - mode
      - description
-   * - disabled
-     - Skip checking ``regex``, but leave other formats enabled.
    * - default
-     - Check for known non-python regex syntaxes. If one is found, the expression
-       always passes. Otherwise, check validity in the python engine.
+     - Require the regex to be valid in ECMAScript regex syntax.
    * - python
-     - Require the regex to be valid in python regex syntax.
+     - Require the regex to be valid in Python regex syntax.
 
 Other Options
 --------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ install_requires =
     importlib-resources>=1.4.0;python_version<"3.9"
     ruamel.yaml==0.17.32
     jsonschema>=4.18.0,<5.0
+    regress>=0.4.0
     requests<3.0
     click>=8,<9
 package_dir=

--- a/src/check_jsonschema/cli/main_command.py
+++ b/src/check_jsonschema/cli/main_command.py
@@ -7,7 +7,7 @@ import click
 
 from ..catalog import CUSTOM_SCHEMA_NAMES, SCHEMA_CATALOG
 from ..checker import SchemaChecker
-from ..formats import KNOWN_FORMATS, RegexFormatBehavior
+from ..formats import KNOWN_FORMATS, RegexVariantName
 from ..instance_loader import InstanceLoader
 from ..parsers import SUPPORTED_FILE_FORMATS
 from ..reporter import REPORTER_BY_NAME, Reporter
@@ -69,8 +69,7 @@ including the following formats by default:
 \b
 For the "regex" format, there are multiple modes which can be specified with
 '--format-regex':
-    default  |  best effort check
-    disabled |  do not check the regex format
+    default  |  check that the string is a valid ECMAScript regex
     python   |  check that the string is a valid python regex
 
 \b
@@ -153,8 +152,8 @@ The '--disable-formats' flag supports the following formats:
         "Set the mode of format validation for regexes. "
         "If `--disable-formats regex` is used, this option has no effect."
     ),
-    default=RegexFormatBehavior.default.value,
-    type=click.Choice([x.value for x in RegexFormatBehavior], case_sensitive=False),
+    default=RegexVariantName.default.value,
+    type=click.Choice([x.value for x in RegexVariantName], case_sensitive=False),
 )
 @click.option(
     "--default-filetype",
@@ -249,7 +248,7 @@ def main(
         args.disable_all_formats = True
     else:
         args.disable_formats = normalized_disable_formats
-    args.format_regex = RegexFormatBehavior(format_regex)
+    args.format_regex = RegexVariantName(format_regex)
     args.disable_cache = no_cache
     args.default_filetype = default_filetype
     args.fill_defaults = fill_defaults

--- a/src/check_jsonschema/cli/parse_result.py
+++ b/src/check_jsonschema/cli/parse_result.py
@@ -4,7 +4,7 @@ import enum
 
 import click
 
-from ..formats import FormatOptions, RegexFormatBehavior
+from ..formats import FormatOptions, RegexVariantName
 from ..transforms import Transform
 
 
@@ -33,7 +33,7 @@ class ParseResult:
         # regex format options
         self.disable_all_formats: bool = False
         self.disable_formats: tuple[str, ...] = ()
-        self.format_regex: RegexFormatBehavior = RegexFormatBehavior.default
+        self.format_regex: RegexVariantName = RegexVariantName.default
         # error and output controls
         self.verbosity: int = 1
         self.traceback_mode: str = "short"
@@ -69,6 +69,6 @@ class ParseResult:
     def format_opts(self) -> FormatOptions:
         return FormatOptions(
             enabled=not self.disable_all_formats,
-            regex_behavior=self.format_regex,
+            regex_variant=self.format_regex,
             disabled_formats=self.disable_formats,
         )


### PR DESCRIPTION
The default regex check mode gets a significant upgrade here to support ECMAScript standard regexes via the 'regress' package and underlying crate. This should now fully validate regexes in many more scenarios, rather than doing a best-effort check.

Since this is a change which touches regex behavior in a significant way, the opportunity is also taken to remove support for `--format-regex disabled`.
Users should be converted to the `--disable-formats` flag, which supports this via `--disable-formats regex`.

Tests are given mild updates to drop the `disabled` value for that flag, but use `--disable-formats regex` instead.
And the implementation is very mildly refactored to hopefully support plugging the `regress` implementation into more of `jsonschema` in the future.