### PR TITLE
Convert build pipelines to use two jobs

### DIFF
--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -5,11 +5,8 @@ on:
     types: [published]
 
 jobs:
-  publish:
+  build-dists:
     runs-on: ubuntu-latest
-    environment: publish
-    permissions:
-      id-token: write
 
     steps:
       - uses: actions/checkout@v3
@@ -17,8 +14,31 @@ jobs:
         with:
           python-version: "3.11"
 
-      - run: python -m pip install build
-      - run: python -m build .
+      - run: python -m pip install build twine
+
+      - name: Build Dists
+        run: python -m build .
+
+      - name: Check Dists (twine)
+        run: twine check dist/*
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: packages
+          path: dist/*
+
+  publish:
+    needs: [build-dists]
+    runs-on: ubuntu-latest
+    environment: publish-testpypi
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: packages
+          path: dist
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish_to_test_pypi.yaml
+++ b/.github/workflows/publish_to_test_pypi.yaml
@@ -12,11 +12,8 @@ on:
     tags: ["*"]
 
 jobs:
-  publish:
+  build-dists:
     runs-on: ubuntu-latest
-    environment: publish-testpypi
-    permissions:
-      id-token: write
 
     steps:
       - uses: actions/checkout@v3
@@ -24,7 +21,7 @@ jobs:
         with:
           python-version: "3.11"
 
-      - run: python -m pip install build
+      - run: python -m pip install build twine
 
       - name: Set dev version prior to upload (auto)
         if: ${{ github.event.inputs.devNumber == '' }}
@@ -34,9 +31,32 @@ jobs:
         if: ${{ github.event.inputs.devNumber != '' }}
         run: python ./scripts/set-dev-version.py -n ${{ github.event.inputs.devNumber }}
 
-      - run: python -m build .
+      - name: Build Dists
+        run: python -m build .
+
+      - name: Check Dists (twine)
+        run: twine check dist/*
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: packages
+          path: dist/*
+
+
+  publish:
+    needs: [build-dists]
+    runs-on: ubuntu-latest
+    environment: publish-testpypi
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: packages
+          path: dist
 
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
This avoids exposing the GitHub token (`id-token: write`) used for trusted publishing to the build process (`build` and the underlying backend), improving security via isolation.

Also, add `twine check` to the build+publish pipeline, per the recommendations of various publishing guides, to catch malformed metadata.

Big thanks to @webknjaz for spotting this improvement and for providing tools, docs, and guidance for publishing!

---

For reference, this originated here:
https://github.com/python-jsonschema/check-jsonschema/commit/a9a3504ef9bcd19d410a0b9f5ac25a1f184e496e#r125529549