### PR TITLE
Remove the deprecated disable-format flag

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ Unreleased
   default. (:issue:`302`)
 - The ``--format-regex disabled`` option has been removed. Users should use
   ``--disable-formats regex`` if they wish to disable regex format checking.
+- The deprecated ``--disable-format`` flag has been removed. Users should use
+  ``--disable-formats "*"`` if they wish to disable all format checking.
 
 0.25.0
 ------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -136,15 +136,6 @@ that any validation for formats be applied.
 ``check-jsonschema`` supports checking several ``"format"``\s by default. The
 following options can be used to control this behavior.
 
-``--disable-format``
-~~~~~~~~~~~~~~~~~~~~
-
-.. warning::
-
-    This option is deprecated. Use ``--disable-formats "*"`` instead.
-
-Disable all format checks.
-
 ``--disable-formats``
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/check_jsonschema/cli/main_command.py
+++ b/src/check_jsonschema/cli/main_command.py
@@ -20,7 +20,6 @@ from ..schema_loader import (
 from ..transforms import TRANSFORM_LIBRARY
 from .param_types import CommaDelimitedList
 from .parse_result import ParseResult, SchemaLoadingMode
-from .warnings import deprecation_warning_callback
 
 BUILTIN_SCHEMA_NAMES = [f"vendor.{k}" for k in SCHEMA_CATALOG.keys()] + [
     f"custom.{k}" for k in CUSTOM_SCHEMA_NAMES
@@ -128,17 +127,6 @@ The '--disable-formats' flag supports the following formats:
     ),
 )
 @click.option(
-    "--disable-format",
-    is_flag=True,
-    help="{deprecated} Disable all format checks in the schema.",
-    callback=deprecation_warning_callback(
-        "--disable-format",
-        is_flag=True,
-        append_message="Users should now pass '--disable-formats \"*\"' for "
-        "the same functionality.",
-    ),
-)
-@click.option(
     "--disable-formats",
     multiple=True,
     help="Disable specific format checks in the schema. "
@@ -223,7 +211,6 @@ def main(
     check_metaschema: bool,
     no_cache: bool,
     cache_filename: str | None,
-    disable_format: bool,
     disable_formats: tuple[list[str], ...],
     format_regex: str,
     default_filetype: str,
@@ -244,10 +231,11 @@ def main(
     normalized_disable_formats: tuple[str, ...] = tuple(
         f for sublist in disable_formats for f in sublist
     )
-    if disable_format or "*" in normalized_disable_formats:
+    if "*" in normalized_disable_formats:
         args.disable_all_formats = True
     else:
         args.disable_formats = normalized_disable_formats
+
     args.format_regex = RegexVariantName(format_regex)
     args.disable_cache = no_cache
     args.default_filetype = default_filetype

--- a/tests/unit/test_cli_parse.py
+++ b/tests/unit/test_cli_parse.py
@@ -258,12 +258,3 @@ def test_disable_all_formats(runner, mock_parse_result, addargs):
         + addargs,
     )
     assert mock_parse_result.disable_all_formats is True
-
-
-def test_disable_format_deprecated_flag(runner, mock_parse_result):
-    # this should be an override, with or without other args
-    with pytest.warns(UserWarning, match="'--disable-format' is deprecated"):
-        runner.invoke(
-            cli_main, ["--schemafile", "schema.json", "foo.json", "--disable-format"]
-        )
-    assert mock_parse_result.disable_all_formats is True


### PR DESCRIPTION
In concert with changes to `--format-regex`, this gets us to a place where there is only one flag which is canonically correct for disabling format checks.