### PR TITLE
Fix a minor bug with verbose output

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ Unreleased
 
 .. vendor-insert-here
 
+- Fix a minor bug with the verbose output introduced in v0.26.2
+
 0.26.2
 ------
 

--- a/src/check_jsonschema/checker.py
+++ b/src/check_jsonschema/checker.py
@@ -69,9 +69,11 @@ class SchemaChecker:
                 result.record_parse_error(path, data)
             else:
                 validator = self.get_validator(path, data)
+                passing = True
                 for err in validator.iter_errors(data):
                     result.record_validation_error(path, err)
-                else:
+                    passing = False
+                if passing:
                     result.record_validation_success(path)
         return result
 

--- a/src/check_jsonschema/reporter.py
+++ b/src/check_jsonschema/reporter.py
@@ -199,7 +199,7 @@ class JsonReporter(Reporter):
     def report_errors(self, result: CheckResult) -> None:
         report_obj: dict[str, t.Any] = {"status": "fail"}
         if self.verbosity > 1:
-            report_obj["checked_paths"] = list(result.successes)
+            report_obj["successes"] = list(result.successes)
         if self.verbosity > 0:
             report_obj["errors"] = list(self._dump_error_map(result.validation_errors))
             report_obj["parse_errors"] = list(


### PR DESCRIPTION
All files were being listed  in JSON output reporting, rather than
only the successful files. This would be fine if it were the intended
behavior, but it is not -- the internal list being built is named
"successes" and is meant to track the passing files, excluding the
failing ones.
