### PR TITLE
feat: add mkdocs-material schema to catalog

### DIFF
--- a/src/check_jsonschema/catalog.py
+++ b/src/check_jsonschema/catalog.py
@@ -110,6 +110,14 @@ SCHEMA_CATALOG: dict[str, dict[str, t.Any]] = {
             "types": "yaml",
         },
     },
+    "mkdocs-material": {
+        "url": "https://squidfunk.github.io/mkdocs-material/schema.json",
+        "hook_config": {
+            "name": "Validate MkDocs Material Config",
+            "files": r"^mkdocs\.yml$",
+            "types": "yaml",
+        },
+    },
     "readthedocs": {
         "url": _githubusercontent_url(
             "readthedocs",


### PR DESCRIPTION
Schema json for MkDocs Material (<https://github.com/squidfunk/mkdocs-material>)

See <https://squidfunk.github.io/mkdocs-material/creating-your-site/> for filename and schema link.