### PR TITLE
Add --validator-class option for passing a validator class

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -251,3 +251,26 @@ not set.
 
 ``--base-uri`` overrides this behavior, setting a custom base URI for ``$ref``
 resolution.
+
+``--validator-class``
+~~~~~~~~~~~~~~~~~~~~~
+
+``check-jsonschema`` allows users to pass a custom validator class which
+implements the ``jsonschema.protocols.Validator`` protocol.
+
+The format used for this argument is ``<module>:<class>``. For example, to
+explicitly use the ``jsonschema`` validator for Draft7, use
+``--validator-class 'jsonschema.validators:Draft7Validator'``.
+
+The module containing the validator class must be importable from within the
+``check-jsonschema`` runtime context.
+
+.. note::
+
+    ``check-jsonschema`` will treat the validator class similarly to the
+    ``jsonschema`` library builtin validators. This includes using documented
+    extension points like passing a format checker or the behavior enabled with
+    ``--fill-defaults``. Users of this feature are recommended to build their
+    validators using ``jsonschema``'s documented interfaces (e.g.
+    ``jsonschema.validators.extend``) to ensure that their validators are
+    compatible.

--- a/src/check_jsonschema/cli/main_command.py
+++ b/src/check_jsonschema/cli/main_command.py
@@ -290,6 +290,7 @@ def build_schema_loader(args: ParseResult) -> SchemaLoaderBase:
             args.cache_filename,
             args.disable_cache,
             base_uri=args.base_uri,
+            validator_class=args.validator_class,
         )
     else:
         raise NotImplementedError("no valid schema option provided")

--- a/src/check_jsonschema/cli/param_types.py
+++ b/src/check_jsonschema/cli/param_types.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import importlib
 import re
 import typing as t
-import warnings
 
 import click
 import jsonschema
@@ -101,17 +100,7 @@ class ValidatorClassName(click.ParamType):
                 ctx,
             )
 
-        if not callable(result):
-            self.fail(
-                f"'{classname}' in '{pkg}' is not a class or callable", param, ctx
-            )
-
         if not isinstance(result, type):
-            warnings.warn(
-                f"'{classname}' in '{pkg}' is not a class. If it is a function "
-                f"returning a Validator, it still might work, but this usage "
-                "is not recommended.",
-                stacklevel=1,
-            )
+            self.fail(f"'{classname}' in '{pkg}' is not a class", param, ctx)
 
         return t.cast(t.Type[jsonschema.protocols.Validator], result)

--- a/src/check_jsonschema/cli/param_types.py
+++ b/src/check_jsonschema/cli/param_types.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
+import importlib
+import re
 import typing as t
+import warnings
 
 import click
+import jsonschema
 
 
 class CommaDelimitedList(click.ParamType):
+    name = "comma_delimited"
+
     def __init__(
         self,
         *,
@@ -43,3 +49,69 @@ class CommaDelimitedList(click.ParamType):
                 )
 
         return resolved
+
+
+class ValidatorClassName(click.ParamType):
+    name = "validator"
+
+    def convert(
+        self, value: str, param: click.Parameter | None, ctx: click.Context | None
+    ) -> type[jsonschema.protocols.Validator]:
+        """
+        Use a colon-based parse to split this up and do the import with importlib.
+        This method is inspired by pkgutil.resolve_name and uses the newer syntax
+        documented there.
+
+        pkgutil supports both
+            W(.W)*
+        and
+            W(.W)*:(W(.W)*)?
+        as patterns, but notes that the first one is for backwards compatibility only.
+        The second form is preferred because it clarifies the division between the
+        importable name and any namespaced path to an object or class.
+
+        As a result, only one import is needed, rather than iterative imports over the
+        list of names.
+        """
+        value = super().convert(value, param, ctx)
+        pattern = re.compile(
+            r"^(?P<pkg>(?!\d)(\w+)(\.(?!\d)(\w+))*):"
+            r"(?P<cls>(?!\d)(\w+)(\.(?!\d)(\w+))*)$"
+        )
+        m = pattern.match(value)
+        if m is None:
+            self.fail(
+                f"'{value}' is not a valid specifier in '<package>:<class>' form",
+                param,
+                ctx,
+            )
+        pkg = m.group("pkg")
+        classname = m.group("cls")
+        try:
+            result: t.Any = importlib.import_module(pkg)
+        except ImportError as e:
+            self.fail(f"'{pkg}' was not an importable module. {str(e)}", param, ctx)
+        try:
+            for part in classname.split("."):
+                result = getattr(result, part)
+        except AttributeError as e:
+            self.fail(
+                f"'{classname}' was not resolvable to a class in '{pkg}'. {str(e)}",
+                param,
+                ctx,
+            )
+
+        if not callable(result):
+            self.fail(
+                f"'{classname}' in '{pkg}' is not a class or callable", param, ctx
+            )
+
+        if not isinstance(result, type):
+            warnings.warn(
+                f"'{classname}' in '{pkg}' is not a class. If it is a function "
+                f"returning a Validator, it still might work, but this usage "
+                "is not recommended.",
+                stacklevel=1,
+            )
+
+        return t.cast(t.Type[jsonschema.protocols.Validator], result)

--- a/tests/acceptance/test_custom_validator_class.py
+++ b/tests/acceptance/test_custom_validator_class.py
@@ -1,0 +1,149 @@
+import json
+
+import pytest
+
+# define a calendar event schema and then use a custom validator to validate that there
+# are no events with "Occult" in their names
+SCHEMA = {
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "definitions": {
+        "calendar-event": {
+            "type": "object",
+            "properties": {
+                "title": {"type": "string"},
+                "start": {"type": "string", "format": "date-time"},
+                "end": {"type": "string", "format": "date-time"},
+            },
+        }
+    },
+    "properties": {
+        "events": {
+            "type": "array",
+            "items": {"$ref": "#/definitions/calendar-event"},
+        },
+    },
+    "required": ["events"],
+}
+VALID_DOC = {
+    "events": [
+        {
+            "title": "Weekly Production Meeting",
+            "start": "2019-06-24T09:00:00-05:00",
+            "end": "2019-06-24T10:00:00-05:00",
+        },
+        {
+            "title": "Catch Up",
+            "start": "2019-06-24T10:00:00-05:00",
+            "end": "2019-06-24T10:30:00-05:00",
+        },
+    ]
+}
+INVALID_DOC = {
+    "events": [
+        {
+            "title": "Weekly Production Meeting",
+            "start": "2019-06-24T09:00:00-05:00",
+            "end": "2019-06-24T10:00:00-05:00",
+        },
+        {
+            "title": "Catch Up",
+            "start": "2019-06-24T10:00:00-05:00",
+            "end": "2019-06-24T10:30:00-05:00",
+        },
+        {
+            "title": "Occult Study Session",
+            "start": "2019-06-24T10:00:00-05:00",
+            "end": "2019-06-24T12:00:00-05:00",
+        },
+    ]
+}
+
+
+@pytest.fixture(autouse=True)
+def _foo_module(mock_module):
+    mock_module(
+        "foo.py",
+        """\
+import jsonschema
+
+class MyValidator:
+    def __init__(self, schema, *args, **kwargs):
+        self.schema = schema
+        self.real_validator = jsonschema.validators.Draft7Validator(
+            schema, *args, **kwargs
+        )
+
+    def iter_errors(self, data, *args, **kwargs):
+        yield from self.real_validator.iter_errors(data, *args, **kwargs)
+        for event in data["events"]:
+            if "Occult" in event["title"]:
+                yield jsonschema.exceptions.ValidationError(
+                    "Error! Occult event detected! Run!",
+                    validator=None,
+                    validator_value=None,
+                    instance=event,
+                    schema=self.schema,
+                )
+""",
+    )
+
+
+def test_custom_validator_class_can_detect_custom_conditions(run_line, tmp_path):
+    doc = tmp_path / "invalid.json"
+    doc.write_text(json.dumps(INVALID_DOC))
+
+    schema = tmp_path / "schema.json"
+    schema.write_text(json.dumps(SCHEMA))
+
+    result = run_line(
+        [
+            "check-jsonschema",
+            "--schemafile",
+            str(schema),
+            str(doc),
+        ]
+    )
+    assert result.exit_code == 0, result.stdout  # pass
+
+    result = run_line(
+        [
+            "check-jsonschema",
+            "--schemafile",
+            str(schema),
+            "--validator-class",
+            "foo:MyValidator",
+            str(doc),
+        ],
+    )
+    assert result.exit_code == 1  # fail
+    assert "Occult event detected" in result.stdout, result.stdout
+
+
+def test_custom_validator_class_can_pass_when_valid(run_line, tmp_path):
+    doc = tmp_path / "valid.json"
+    doc.write_text(json.dumps(VALID_DOC))
+
+    schema = tmp_path / "schema.json"
+    schema.write_text(json.dumps(SCHEMA))
+
+    result = run_line(
+        [
+            "check-jsonschema",
+            "--schemafile",
+            str(schema),
+            str(doc),
+        ]
+    )
+    assert result.exit_code == 0, result.stdout  # pass
+
+    result = run_line(
+        [
+            "check-jsonschema",
+            "--schemafile",
+            str(schema),
+            "--validator-class",
+            "foo:MyValidator",
+            str(doc),
+        ],
+    )
+    assert result.exit_code == 0  # pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+import pathlib
+import sys
+
 import pytest
 import responses
 
@@ -8,3 +11,30 @@ def mocked_responses():
     yield
     responses.stop()
     responses.reset()
+
+
+@pytest.fixture
+def mock_module(tmp_path, monkeypatch):
+    monkeypatch.syspath_prepend(tmp_path)
+    all_names_to_clear = []
+
+    def func(path, text):
+        path = pathlib.Path(path)
+        mod_dir = tmp_path / (path.parent)
+        mod_dir.mkdir(parents=True, exist_ok=True)
+        for part in path.parts[:-1]:
+            (tmp_path / part / "__init__.py").touch()
+
+        (tmp_path / path).write_text(text)
+
+        for i in range(len(path.parts)):
+            modname = ".".join(path.parts[: i + 1])
+            if modname.endswith(".py"):
+                modname = modname[:-3]
+            all_names_to_clear.append(modname)
+
+    yield func
+
+    for name in all_names_to_clear:
+        if name in sys.modules:
+            del sys.modules[name]

--- a/tests/unit/test_cli_parse.py
+++ b/tests/unit/test_cli_parse.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import pathlib
-import sys
 from unittest import mock
 
 import click
@@ -27,33 +25,6 @@ def mock_parse_result():
     with mock.patch("check_jsonschema.cli.main_command.ParseResult") as m:
         m.return_value = args
         yield args
-
-
-@pytest.fixture
-def mock_module(tmp_path, monkeypatch):
-    monkeypatch.syspath_prepend(tmp_path)
-    all_names_to_clear = []
-
-    def func(path, text):
-        path = pathlib.Path(path)
-        mod_dir = tmp_path / (path.parent)
-        mod_dir.mkdir(parents=True, exist_ok=True)
-        for part in path.parts[:-1]:
-            (tmp_path / part / "__init__.py").touch()
-
-        (tmp_path / path).write_text(text)
-
-        for i in range(len(path.parts)):
-            modname = ".".join(path.parts[: i + 1])
-            if modname.endswith(".py"):
-                modname = modname[:-3]
-            all_names_to_clear.append(modname)
-
-    yield func
-
-    for name in all_names_to_clear:
-        if name in sys.modules:
-            del sys.modules[name]
 
 
 @pytest.fixture(autouse=True)
@@ -310,9 +281,7 @@ def test_can_specify_custom_validator_class(runner, mock_parse_result, mock_modu
 @pytest.mark.parametrize(
     "failmode", ("syntax", "import", "attr", "function", "non_callable")
 )
-def test_can_custom_validator_class_fails(
-    runner, mock_parse_result, mock_module, failmode
-):
+def test_custom_validator_class_fails(runner, mock_parse_result, mock_module, failmode):
     mock_module(
         "foo.py",
         """\


### PR DESCRIPTION
- Add interface for passing custom validators
- Instrument use of custom --validator-class values
- Restrict --validator-class to types (no functions)
- Add tests for custom validator usage
- Add doc section covering `--validator-class`

---

The basics are all here, and this should resolve #262

For users seeing this, and for comparison with the old `jsonschema` CLI
feature, I have a few notes on the interface and some related topics:

- `--validator-class` is the option name (there is no short opt)

- The syntax for specifying this is slightly different from `--validator` in
  the old CLI -- you must separate your module name from your class name with
  a colon, as in `foopkg.barmodule:MyValidator`.

  - This could be loosened to the purely dotted notation if there's a strong
    argument for doing so, but the interface is simpler and cleaner with this
    syntax, so please think critically about whether or not it's important
    before asking for it to change.

  - As an example usage,
    `--validator-class 'jsonschema.validators.Draft3Validator'`.

  - There is no special case for the `jsonschema` builtin validators

- `check-jsonschema` has a few features which expect the validator class to
  be built only using the documented `jsonschema` interfaces. In particular:

  - `--fill-defaults` uses the `extend` API to modify the validator class
  - a `referencing` registry is used (rather than `RefResolver`) and is passed
    on init
  - a custom format checker is passed on init, and it is *not* derived from
    `FORMAT_CHECKER` on the `--validator-class` value

- Usages may change over time as `jsonschema` and `check-jsonschema` continue
  to evolve. Barring major issues, I do not intend to treat incompatibility
  between a custom validator class and `check-jsonschema` behaviors as a bug.

- The above stated, if `check-jsonschema` is doing something outside of the
  `jsonschema` API contract and it causes issues with a custom validator, that
  *is* a bug; please report any of those and we can get them fixed. :)

- Within the scope of this change, no change is being made to the dependency
  bounds being applied by `check-jsonschema`. There will probably be some
  measure of change to make it easier to control dependency versions used, but
  `check-jsonschema` also has pre-commit hook usage to consider, with its own
  implications about appropriate dependency specification

- `check-jsonschema` currently will not call `check_schema` when using a custom
  validator class (please open an issue if you would like this to change; it is
  a point of flexibility based on user demand)

- The CLI validation currently requires that the value be a `type`, meaning it
  typically has to be a proper python `class`. The possibility of some callback
  or alternative extension point is open *if* a well-reasoned proposal for some
  secondary behavior can be made.

- All of the decisions being made here about the interface, implicit API
  contract, and expectations are subject to change if there's a good reason.
  After all, this is an advanced feature for "power users".
