### PR TITLE
Support reading schemafiles and instancefiles from stdin

### DIFF
--- a/src/check_jsonschema/checker.py
+++ b/src/check_jsonschema/checker.py
@@ -47,7 +47,7 @@ class SchemaChecker:
         raise _Exit(1)
 
     def get_validator(
-        self, path: pathlib.Path, doc: dict[str, t.Any]
+        self, path: pathlib.Path | str, doc: dict[str, t.Any]
     ) -> jsonschema.protocols.Validator:
         try:
             return self._schema_loader.get_validator(

--- a/src/check_jsonschema/cli/main_command.py
+++ b/src/check_jsonschema/cli/main_command.py
@@ -91,8 +91,10 @@ The '--disable-formats' flag supports the following formats:
     help=(
         "The path to a file containing the JSON Schema to use or an "
         "HTTP(S) URI for the schema. If a remote file is used, "
-        "it will be downloaded and cached locally based on mtime."
+        "it will be downloaded and cached locally based on mtime. "
+        "Use '-' for stdin."
     ),
+    metavar="[PATH|URI]",
 )
 @click.option(
     "--base-uri",

--- a/src/check_jsonschema/cli/main_command.py
+++ b/src/check_jsonschema/cli/main_command.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import textwrap
+import typing as t
 
 import click
 import jsonschema
@@ -217,7 +218,7 @@ The '--disable-formats' flag supports the following formats:
     help="Reduce output verbosity",
     count=True,
 )
-@click.argument("instancefiles", required=True, nargs=-1)
+@click.argument("instancefiles", required=True, nargs=-1, type=click.File("rb"))
 def main(
     *,
     schemafile: str | None,
@@ -236,7 +237,7 @@ def main(
     output_format: str,
     verbose: int,
     quiet: int,
-    instancefiles: tuple[str, ...],
+    instancefiles: tuple[t.BinaryIO, ...],
 ) -> None:
     args = ParseResult()
 

--- a/src/check_jsonschema/cli/parse_result.py
+++ b/src/check_jsonschema/cli/parse_result.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import enum
+import typing as t
 
 import click
 import jsonschema
@@ -21,7 +22,7 @@ class ParseResult:
         self.schema_mode: SchemaLoadingMode = SchemaLoadingMode.filepath
         self.schema_path: str | None = None
         self.base_uri: str | None = None
-        self.instancefiles: tuple[str, ...] = ()
+        self.instancefiles: tuple[t.BinaryIO, ...] = ()
         # cache controls
         self.disable_cache: bool = False
         self.cache_filename: str | None = None

--- a/src/check_jsonschema/result.py
+++ b/src/check_jsonschema/result.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 
 import jsonschema
@@ -15,18 +17,18 @@ class CheckResult:
     def success(self) -> bool:
         return not (bool(self.parse_errors) or bool(self.validation_errors))
 
-    def record_validation_success(self, path: pathlib.Path) -> None:
+    def record_validation_success(self, path: pathlib.Path | str) -> None:
         self.successes.append(str(path))
 
     def record_validation_error(
-        self, path: pathlib.Path, err: jsonschema.ValidationError
+        self, path: pathlib.Path | str, err: jsonschema.ValidationError
     ) -> None:
         filename = str(path)
         if filename not in self.validation_errors:
             self.validation_errors[filename] = []
         self.validation_errors[filename].append(err)
 
-    def record_parse_error(self, path: pathlib.Path, err: ParseError) -> None:
+    def record_parse_error(self, path: pathlib.Path | str, err: ParseError) -> None:
         filename = str(path)
         if filename not in self.parse_errors:
             self.parse_errors[filename] = []

--- a/src/check_jsonschema/schema_loader/main.py
+++ b/src/check_jsonschema/schema_loader/main.py
@@ -47,7 +47,7 @@ def _extend_with_default(
 class SchemaLoaderBase:
     def get_validator(
         self,
-        path: pathlib.Path,
+        path: pathlib.Path | str,
         instance_doc: dict[str, t.Any],
         format_opts: FormatOptions,
         fill_defaults: bool,
@@ -117,7 +117,7 @@ class SchemaLoader(SchemaLoaderBase):
 
     def get_validator(
         self,
-        path: pathlib.Path,
+        path: pathlib.Path | str,
         instance_doc: dict[str, t.Any],
         format_opts: FormatOptions,
         fill_defaults: bool,
@@ -189,7 +189,7 @@ class MetaSchemaLoader(SchemaLoaderBase):
 
     def get_validator(
         self,
-        path: pathlib.Path,
+        path: pathlib.Path | str,
         instance_doc: dict[str, t.Any],
         format_opts: FormatOptions,
         fill_defaults: bool,

--- a/src/check_jsonschema/schema_loader/main.py
+++ b/src/check_jsonschema/schema_loader/main.py
@@ -12,7 +12,7 @@ from ..formats import FormatOptions, make_format_checker
 from ..parsers import ParserSet
 from ..utils import is_url_ish
 from .errors import UnsupportedUrlScheme
-from .readers import HttpSchemaReader, LocalSchemaReader
+from .readers import HttpSchemaReader, LocalSchemaReader, StdinSchemaReader
 from .resolver import make_reference_registry
 
 
@@ -82,15 +82,22 @@ class SchemaLoader(SchemaLoaderBase):
         self._parsers = ParserSet()
 
         # setup a schema reader lazily, when needed
-        self._reader: LocalSchemaReader | HttpSchemaReader | None = None
+        self._reader: LocalSchemaReader | HttpSchemaReader | StdinSchemaReader | None = (
+            None
+        )
 
     @property
-    def reader(self) -> LocalSchemaReader | HttpSchemaReader:
+    def reader(self) -> LocalSchemaReader | HttpSchemaReader | StdinSchemaReader:
         if self._reader is None:
             self._reader = self._get_schema_reader()
         return self._reader
 
-    def _get_schema_reader(self) -> LocalSchemaReader | HttpSchemaReader:
+    def _get_schema_reader(
+        self,
+    ) -> LocalSchemaReader | HttpSchemaReader | StdinSchemaReader:
+        if self.schemafile == "-":
+            return StdinSchemaReader()
+
         if self.url_info is None or self.url_info.scheme in ("file", ""):
             return LocalSchemaReader(self.schemafile)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 import sys
 
@@ -38,3 +39,10 @@ def mock_module(tmp_path, monkeypatch):
     for name in all_names_to_clear:
         if name in sys.modules:
             del sys.modules[name]
+
+
+@pytest.fixture
+def in_tmp_dir(request, tmp_path):
+    os.chdir(str(tmp_path))
+    yield
+    os.chdir(request.config.invocation_dir)


### PR DESCRIPTION
- Support stdin for instancefiles using '-'
  - instancefiles are read using `click.File("rb")`
  - the resulting IO objects are passed around, rather than the filenames or path objects
  - tests need to account for this change in the InstanceLoader
- Support stdin for `--schemafile` using '-'
- Add a new test for these usages