### PR TITLE
Support expressions in GHA require-timeout schema

### DIFF
--- a/src/check_jsonschema/builtin_schemas/custom/github-workflows-require-timeout.json
+++ b/src/check_jsonschema/builtin_schemas/custom/github-workflows-require-timeout.json
@@ -1,6 +1,13 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$comment": "A schema which requires that github workflow jobs define job timeouts",
+  "definitions": {
+    "expressionSyntax": {
+      "type": "string",
+      "$comment": "pattern definition taken from schemastore 'github-workflow.json'",
+      "pattern": "^\\$\\{\\{(.|[\r\n])*\\}\\}$"
+    }
+  },
   "properties": {
     "jobs": {
       "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobs",
@@ -15,8 +22,15 @@
                 "timeout-minutes": {
                   "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes",
                   "description": "The maximum number of minutes to let a workflow run before GitHub automatically cancels it. Default: 360",
-                  "type": "number",
-                  "default": 360
+                  "default": 360,
+                  "oneOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "$ref": "#/definitions/expressionSyntax"
+                    }
+                  ]
                 }
               },
               "required": [

--- a/tests/acceptance/test_example_files.py
+++ b/tests/acceptance/test_example_files.py
@@ -64,7 +64,7 @@ def test_hook_positive_examples(case_name, run_line):
 
     hook_id = POSITIVE_HOOK_CASES[case_name]
     ret = run_line(HOOK_CONFIG[hook_id] + [rcase.path] + rcase.add_args)
-    assert ret.exit_code == 0
+    assert ret.exit_code == 0, _format_cli_result(rcase, ret)
 
 
 @pytest.mark.parametrize("case_name", NEGATIVE_HOOK_CASES.keys())
@@ -73,7 +73,7 @@ def test_hook_negative_examples(case_name, run_line):
 
     hook_id = NEGATIVE_HOOK_CASES[case_name]
     ret = run_line(HOOK_CONFIG[hook_id] + [rcase.path] + rcase.add_args)
-    assert ret.exit_code == 1
+    assert ret.exit_code == 1, _format_cli_result(rcase, ret)
 
 
 @pytest.mark.parametrize("case_name", _get_explicit_cases("positive"))
@@ -167,3 +167,13 @@ def _package_is_installed(pkg: str) -> bool:
     if spec is None:
         return False
     return True
+
+
+def _format_cli_result(rcase: ResolvedCase, result) -> str:
+    return (
+        "\n"
+        f"config.add_args={rcase.add_args}\n"
+        f"{result.exit_code=}\n"
+        f"result.stdout={result.output}\n"
+        f"{result.stderr=}"
+    )

--- a/tests/example-files/hooks/negative/jsonschema/_config.yaml
+++ b/tests/example-files/hooks/negative/jsonschema/_config.yaml
@@ -1,0 +1,3 @@
+files:
+  github-workflow-timeout-minutes-expression.yaml:
+    add_args: ["--builtin-schema", "custom.github-workflows-require-timeout"]

--- a/tests/example-files/hooks/negative/jsonschema/github-workflow-timeout-minutes-expression.yaml
+++ b/tests/example-files/hooks/negative/jsonschema/github-workflow-timeout-minutes-expression.yaml
@@ -1,0 +1,12 @@
+on:
+  workflow-call:
+    inputs:
+      qemu:
+          default: ''
+          required: false
+
+jobs:
+  job-id:
+    runs-on: ubuntu-latest
+    # missing trailing '}'
+    timeout-minutes: ${{ inputs.qemu && '60' || '20' }

--- a/tests/example-files/hooks/positive/jsonschema/_config.yaml
+++ b/tests/example-files/hooks/positive/jsonschema/_config.yaml
@@ -1,0 +1,3 @@
+files:
+  github-workflow-timeout-minutes-expression.yaml:
+    add_args: ["--builtin-schema", "custom.github-workflows-require-timeout"]

--- a/tests/example-files/hooks/positive/jsonschema/github-workflow-timeout-minutes-expression.yaml
+++ b/tests/example-files/hooks/positive/jsonschema/github-workflow-timeout-minutes-expression.yaml
@@ -1,0 +1,11 @@
+on:
+  workflow-call:
+    inputs:
+      qemu:
+          default: ''
+          required: false
+
+jobs:
+  job-id:
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.qemu && '60' || '20' }}


### PR DESCRIPTION
github-workflows-require-timeout now supports expression eval blocks in the value for the timeout. Two test-cases ensure that such workflows will pass, based on the example provided in #354

resolves #354

There is also a small refinement to test outputs here, which was added while testing this addition.