### PR TITLE
Improve file handling with lazy reads

### DIFF
--- a/src/check_jsonschema/cli/main_command.py
+++ b/src/check_jsonschema/cli/main_command.py
@@ -20,7 +20,7 @@ from ..schema_loader import (
     SchemaLoaderBase,
 )
 from ..transforms import TRANSFORM_LIBRARY
-from .param_types import CommaDelimitedList, ValidatorClassName
+from .param_types import CommaDelimitedList, LazyBinaryReadFile, ValidatorClassName
 from .parse_result import ParseResult, SchemaLoadingMode
 
 BUILTIN_SCHEMA_NAMES = [f"vendor.{k}" for k in SCHEMA_CATALOG.keys()] + [
@@ -220,7 +220,9 @@ The '--disable-formats' flag supports the following formats:
     help="Reduce output verbosity",
     count=True,
 )
-@click.argument("instancefiles", required=True, nargs=-1, type=click.File("rb"))
+@click.argument(
+    "instancefiles", required=True, nargs=-1, type=LazyBinaryReadFile("rb", lazy=True)
+)
 def main(
     *,
     schemafile: str | None,

--- a/src/check_jsonschema/cli/param_types.py
+++ b/src/check_jsonschema/cli/param_types.py
@@ -141,11 +141,16 @@ class _CustomLazyFile(click.utils.LazyFile):
 class LazyBinaryReadFile(click.File):
     def convert(
         self,
-        value: str,
+        value: str | os.PathLike[str] | t.IO[t.Any],
         param: click.Parameter | None,
         ctx: click.Context | None,
     ) -> t.IO[bytes]:
-        lf = _CustomLazyFile(value, mode="rb")
+        if hasattr(value, "read") or hasattr(value, "write"):
+            return t.cast(t.IO[bytes], value)
+
+        value_: str | os.PathLike[str] = t.cast("str | os.PathLike[str]", value)
+
+        lf = _CustomLazyFile(value_, mode="rb")
         if ctx is not None:
             ctx.call_on_close(lf.close_intelligently)
         return t.cast(t.IO[bytes], lf)

--- a/src/check_jsonschema/cli/param_types.py
+++ b/src/check_jsonschema/cli/param_types.py
@@ -109,7 +109,7 @@ class ValidatorClassName(click.ParamType):
         return t.cast(t.Type[jsonschema.protocols.Validator], result)
 
 
-class _CustomLazyFile(click.utils.LazyFile):
+class CustomLazyFile(click.utils.LazyFile):
     def __init__(
         self,
         filename: str | os.PathLike[str],
@@ -150,7 +150,7 @@ class LazyBinaryReadFile(click.File):
 
         value_: str | os.PathLike[str] = t.cast("str | os.PathLike[str]", value)
 
-        lf = _CustomLazyFile(value_, mode="rb")
+        lf = CustomLazyFile(value_, mode="rb")
         if ctx is not None:
             ctx.call_on_close(lf.close_intelligently)
         return t.cast(t.IO[bytes], lf)

--- a/src/check_jsonschema/instance_loader.py
+++ b/src/check_jsonschema/instance_loader.py
@@ -43,4 +43,6 @@ class InstanceLoader:
                 data = err
             else:
                 data = self._data_transform(data)
+
+            file.close()
             yield (name, data)

--- a/src/check_jsonschema/instance_loader.py
+++ b/src/check_jsonschema/instance_loader.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import io
 import typing as t
 
+from check_jsonschema.cli.param_types import CustomLazyFile
+
 from .parsers import ParseError, ParserSet
 from .transforms import Transform
 
@@ -10,7 +12,7 @@ from .transforms import Transform
 class InstanceLoader:
     def __init__(
         self,
-        files: t.Sequence[t.BinaryIO],
+        files: t.Sequence[t.BinaryIO | CustomLazyFile],
         default_filetype: str = "json",
         data_transform: Transform | None = None,
     ) -> None:
@@ -35,14 +37,21 @@ class InstanceLoader:
                 name = "<stdin>"
             else:
                 raise ValueError(f"File {file} has no name attribute")
-            try:
-                data: t.Any = self._parsers.parse_data_with_path(
-                    file, name, self._default_filetype
-                )
-            except ParseError as err:
-                data = err
-            else:
-                data = self._data_transform(data)
 
-            file.close()
+            try:
+                if isinstance(file, CustomLazyFile):
+                    stream: t.BinaryIO = t.cast(t.BinaryIO, file.open())
+                else:
+                    stream = file
+
+                try:
+                    data: t.Any = self._parsers.parse_data_with_path(
+                        stream, name, self._default_filetype
+                    )
+                except ParseError as err:
+                    data = err
+                else:
+                    data = self._data_transform(data)
+            finally:
+                file.close()
             yield (name, data)

--- a/src/check_jsonschema/schema_loader/readers.py
+++ b/src/check_jsonschema/schema_loader/readers.py
@@ -49,7 +49,7 @@ class LocalSchemaReader:
     def read_schema(self) -> dict:
         if self._parsed_schema is _UNSET:
             self._parsed_schema = _run_load_callback(self.filename, self._read_impl)
-        return self._parsed_schema
+        return t.cast(dict, self._parsed_schema)
 
 
 class StdinSchemaReader:
@@ -66,7 +66,7 @@ class StdinSchemaReader:
                 self._parsed_schema = json.load(sys.stdin)
             except ValueError as e:
                 raise ParseError("Failed to parse JSON from stdin") from e
-        return self._parsed_schema
+        return t.cast(dict, self._parsed_schema)
 
 
 class HttpSchemaReader:
@@ -101,4 +101,4 @@ class HttpSchemaReader:
     def read_schema(self) -> dict:
         if self._parsed_schema is _UNSET:
             self._parsed_schema = _run_load_callback(self.url, self._read_impl)
-        return self._parsed_schema
+        return t.cast(dict, self._parsed_schema)

--- a/tests/unit/test_cli_parse.py
+++ b/tests/unit/test_cli_parse.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import io
 from unittest import mock
 
 import click
@@ -86,7 +85,7 @@ def test_schemafile_and_instancefile(runner, mock_parse_result, in_tmp_dir, tmp_
     assert mock_parse_result.schema_path == "schema.json"
     assert isinstance(mock_parse_result.instancefiles, tuple)
     for f in mock_parse_result.instancefiles:
-        assert isinstance(f, (io.BytesIO, io.BufferedReader))
+        assert isinstance(f, click.utils.LazyFile)
     assert tuple(f.name for f in mock_parse_result.instancefiles) == ("foo.json",)
 
 

--- a/tests/unit/test_lazy_file_handling.py
+++ b/tests/unit/test_lazy_file_handling.py
@@ -1,0 +1,43 @@
+import os
+
+import pytest
+from click.testing import CliRunner
+
+from check_jsonschema.cli.main_command import build_checker
+from check_jsonschema.cli.main_command import main as cli_main
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner(mix_stderr=False)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="test requires use of /proc/self/")
+def test_open_file_usage_never_exceeds_1000(runner, monkeypatch, tmp_path):
+    schema_path = tmp_path / "schema.json"
+    schema_path.write_text("{}")
+
+    args = [
+        "--schemafile",
+        str(schema_path),
+    ]
+
+    for i in range(2000):
+        instance_path = tmp_path / f"file{i}.json"
+        instance_path.write_text("{}")
+        args.append(str(instance_path))
+
+    checker = None
+
+    def fake_execute(argv):
+        nonlocal checker
+        checker = build_checker(argv)
+
+    monkeypatch.setattr("check_jsonschema.cli.main_command.execute", fake_execute)
+    res = runner.invoke(cli_main, args)
+    assert res.exit_code == 0, res.stderr
+
+    assert checker is not None
+    assert len(os.listdir("/proc/self/fd")) < 2000
+    for _fname, _data in checker._instance_loader.iter_files():
+        assert len(os.listdir("/proc/self/fd")), 2000

--- a/tests/unit/test_lazy_file_handling.py
+++ b/tests/unit/test_lazy_file_handling.py
@@ -1,4 +1,5 @@
 import os
+import platform
 
 import pytest
 from click.testing import CliRunner
@@ -12,7 +13,9 @@ def runner() -> CliRunner:
     return CliRunner(mix_stderr=False)
 
 
-@pytest.mark.skipif(os.name != "posix", reason="test requires use of /proc/self/")
+@pytest.mark.skipif(
+    platform.system() != "Linux", reason="test requires /proc/self/ mechanism"
+)
 def test_open_file_usage_never_exceeds_1000(runner, monkeypatch, tmp_path):
     schema_path = tmp_path / "schema.json"
     schema_path.write_text("{}")

--- a/tox.ini
+++ b/tox.ini
@@ -46,12 +46,10 @@ commands = coverage report --skip-covered
 
 [testenv:mypy]
 description = "check type annotations with mypy"
-# temporarily pin back click until either click 8.1.5 releases or mypy fixes the issue
-# with referential integrity of type aliases
 deps = mypy
        types-jsonschema
        types-requests
-       click==8.1.3
+       click
 commands = mypy src/ {posargs}
 
 [testenv:pyright]


### PR DESCRIPTION
Primarily this changeset introduces lazy file reading to resolve #352.
Additionally, it introduces a better caching mechanism to the schema file
readers so that schemas read from ephemeral sources (like pipes) can properly
be applied to multiple instances.

See also: pallets/click#2645

- Apply lazy file reading for instancefiles
- Fix schema readers to cache data
- Add a test which verifies lazy file reading
