### PR TITLE
Update catalog by adding an .gitea/workflow check

### DIFF
--- a/src/check_jsonschema/catalog.py
+++ b/src/check_jsonschema/catalog.py
@@ -111,6 +111,14 @@ SCHEMA_CATALOG: dict[str, dict[str, t.Any]] = {
             "types": "yaml",
         },
     },
+    "gitea-workflows": {
+        "url": "https://json.schemastore.org/github-workflow",
+        "hook_config": {
+            "name": "Validate Gitea Workflows",
+            "files": r"^\.gitea/workflows/[^/]+$",
+            "types": "yaml",
+        },
+    },
     "gitlab-ci": {
         "url": "https://gitlab.com/gitlab-org/gitlab/-/raw/master/app/assets/javascripts"
         "/editor/schema/ci.json",


### PR DESCRIPTION
Added an copy of the workflow as an gitea worfklow check.
Gitea uses an act fork. Some features are not implemented.
But since most are. 
So this should be helpfull for useres of gitea actions.
The gitea act fork is an direkt fork that should be keept as a mirror.
Therefore i do not forcee additional maintance requirements for the gitea schema.
