### PR TITLE
Bump upper constraint for `pytest` dev dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ console_scripts =
 
 [options.extras_require]
 dev =
-    pytest<8
+    pytest<9
     coverage<8
     pytest-xdist<4
     responses==0.24.1


### PR DESCRIPTION
[Pytest 8.0](https://docs.pytest.org/en/stable/changelog.html#pytest-8-0-0-2024-01-27) was released a few days ago.

I've run all the tests with `tox` and confirmed that things work as normal with this change.