### PR TITLE
Add support for `orjson` (optional)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,9 @@ Unreleased
 .. vendor-insert-here
 
 - Update vendored schemas (2024-02-05)
+- Support the use of `orjson` for faster JSON parsing when it is installed.
+  This makes it an optional parser which is preferred over the default
+  `json` module when it is available.
 
 0.27.4
 ------

--- a/src/check_jsonschema/parsers/__init__.py
+++ b/src/check_jsonschema/parsers/__init__.py
@@ -1,18 +1,17 @@
 from __future__ import annotations
 
 import io
-import json
 import pathlib
 import typing as t
 
 import ruamel.yaml
 
 from ..identify_filetype import path_to_type
-from . import json5, toml, yaml
+from . import json5, json_, toml, yaml
 
-_PARSER_ERRORS: set[type[Exception]] = {json.JSONDecodeError, yaml.ParseError}
+_PARSER_ERRORS: set[type[Exception]] = {json_.JSONDecodeError, yaml.ParseError}
 DEFAULT_LOAD_FUNC_BY_TAG: dict[str, t.Callable[[t.IO[bytes]], t.Any]] = {
-    "json": json.load,
+    "json": json_.load,
 }
 SUPPORTED_FILE_FORMATS = ["json", "yaml"]
 if json5.ENABLED:

--- a/src/check_jsonschema/parsers/json_.py
+++ b/src/check_jsonschema/parsers/json_.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import json
+import typing as t
+
+try:
+    import orjson
+
+    has_orjson = True
+except ImportError:
+    has_orjson = False
+
+JSONDecodeError = json.JSONDecodeError
+
+
+def load(stream: t.IO[bytes]) -> t.Any:
+    bin_data = stream.read()
+    # if orjson is available, try it first
+    if has_orjson:
+        # in the event of a decode error, it may be that the data contains
+        # `Infinity`, `-Infinity`, or `NaN`
+        #
+        # however, do not failover to stdlib JSON -- it is not obvious that there's any
+        # need for check-jsonschema to support these invalid JSON datatypes
+        # if users encounter issues with this behavior in the future, we can revisit how
+        # JSON loading is handled
+        return orjson.loads(bin_data)
+    # failover to stdlib json
+    return json.loads(bin_data)

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
     py{312,311,310,39,38}
     py310-{notoml,tomli-format}
     py{38,312}-{json5,pyjson5}
+    py{38,312}-{disable_orjson}
     cov
 skip_missing_interpreters = true
 minversion = 4.0.0
@@ -22,6 +23,7 @@ deps =
     mindeps: click==8.0.0
     mindeps: requests==2.0.0
     mindeps: importlib-resources==1.4.0
+    !disable_orjson: orjson
     json5: json5
     pyjson5: pyjson5
     tomli: tomli


### PR DESCRIPTION
This might become a hard dependency in the future, and replace use of
`json` entirely, but for now it's an opt-in feature which should make
parsing of large JSON files faster.
