### PR TITLE
Built-in RFC3339 validator

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,9 @@ Unreleased
 .. vendor-insert-here
 
 - Update vendored schemas (2024-02-05)
+- Include a built-in, efficient implementation of `date-time` format validation
+  (RFC 3339). This makes the `date-time` format always available for
+  validation. (:issue:`378`)
 - Support the use of `orjson` for faster JSON parsing when it is installed.
   This makes it an optional parser which is preferred over the default
   `json` module when it is available.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,9 +11,9 @@ Unreleased
 .. vendor-insert-here
 
 - Update vendored schemas (2024-02-05)
-- Include a built-in, efficient implementation of `date-time` format validation
-  (RFC 3339). This makes the `date-time` format always available for
-  validation. (:issue:`378`)
+- Include built-in, efficient implementations of `date-time` format validation
+  (RFC 3339) and `time` format validation (ISO 8601). This makes the `date-time`
+  and `time` formats always available for validation. (:issue:`378`)
 - Support the use of `orjson` for faster JSON parsing when it is installed.
   This makes it an optional parser which is preferred over the default
   `json` module when it is available.

--- a/src/check_jsonschema/cli/main_command.py
+++ b/src/check_jsonschema/cli/main_command.py
@@ -71,7 +71,7 @@ The schema is specified either with '--schemafile' or with '--builtin-schema'.
 
 'check-jsonschema' supports format checks with appropriate libraries installed,
 including the following formats by default:
-    date, email, ipv4, ipv6, regex, uuid
+    date, date-time, email, ipv4, ipv6, regex, uuid
 
 \b
 For the "regex" format, there are multiple modes which can be specified with

--- a/src/check_jsonschema/formats/__init__.py
+++ b/src/check_jsonschema/formats/__init__.py
@@ -9,7 +9,7 @@ import jsonschema
 import jsonschema.validators
 import regress
 
-from .implementations import validate_rfc3339
+from .implementations import validate_rfc3339, validate_time
 
 # all known format strings except for a selection from draft3 which have either
 # been renamed or removed:
@@ -104,6 +104,7 @@ def make_format_checker(
     regex_impl = RegexImplementation(opts.regex_variant)
     checker.checks("regex")(regex_impl.check_format)
     checker.checks("date-time")(validate_rfc3339)
+    checker.checks("time")(validate_time)
 
     # remove the disabled checks, which may include the regex check
     for checkname in opts.disabled_formats:

--- a/src/check_jsonschema/formats/__init__.py
+++ b/src/check_jsonschema/formats/__init__.py
@@ -9,6 +9,8 @@ import jsonschema
 import jsonschema.validators
 import regress
 
+from .implementations import validate_rfc3339
+
 # all known format strings except for a selection from draft3 which have either
 # been renamed or removed:
 # - color
@@ -101,6 +103,7 @@ def make_format_checker(
     del checker.checkers["regex"]
     regex_impl = RegexImplementation(opts.regex_variant)
     checker.checks("regex")(regex_impl.check_format)
+    checker.checks("date-time")(validate_rfc3339)
 
     # remove the disabled checks, which may include the regex check
     for checkname in opts.disabled_formats:

--- a/src/check_jsonschema/formats/implementations/__init__.py
+++ b/src/check_jsonschema/formats/implementations/__init__.py
@@ -1,3 +1,4 @@
+from .iso8601_time import validate as validate_time
 from .rfc3339 import validate as validate_rfc3339
 
-__all__ = ("validate_rfc3339",)
+__all__ = ("validate_rfc3339", "validate_time")

--- a/src/check_jsonschema/formats/implementations/__init__.py
+++ b/src/check_jsonschema/formats/implementations/__init__.py
@@ -1,0 +1,3 @@
+from .rfc3339 import validate as validate_rfc3339
+
+__all__ = ("validate_rfc3339",)

--- a/src/check_jsonschema/formats/implementations/iso8601_time.py
+++ b/src/check_jsonschema/formats/implementations/iso8601_time.py
@@ -1,0 +1,45 @@
+import re
+
+TIME_REGEX = re.compile(
+    r"""
+    ^
+    (?:[01]\d|2[0123])
+    :
+    (?:[0-5]\d)
+    :
+    (?:[0-5]\d)
+    # (optional) fractional seconds
+    (?:(\.|,)\d+)?
+    # UTC or offset
+    (?:
+        Z
+        | z
+        | [+-](?:[01]\d|2[0123]):[0-5]\d
+    )
+    $
+""",
+    re.VERBOSE | re.ASCII,
+)
+
+
+def validate(time_str: object) -> bool:
+    if not isinstance(time_str, str):
+        return False
+    return bool(TIME_REGEX.match(time_str))
+
+
+if __name__ == "__main__":
+    import timeit
+
+    N = 100_000
+    tests = (
+        ("basic", "23:59:59Z"),
+        ("long_fracsec", "23:59:59.8446519776713Z"),
+    )
+
+    print("benchmarking")
+    for name, val in tests:
+        all_times = timeit.repeat(
+            f"validate({val!r})", globals=globals(), repeat=3, number=N
+        )
+        print(f"{name} (valid={validate(val)}): {int(min(all_times) / N * 10**9)}ns")

--- a/src/check_jsonschema/formats/implementations/rfc3339.py
+++ b/src/check_jsonschema/formats/implementations/rfc3339.py
@@ -1,0 +1,118 @@
+def validate(date_str: str) -> bool:
+    """Validate a string as a RFC3339 date-time.
+
+    This check does the fastest possible validation of the date string (in Python),
+    deferring operations as much as possible to avoid unnecessary work.
+    """
+    try:
+        # the following chars MUST be fixed values:
+        #    YYYY-MM-DDTHH:MM:SSZ
+        #        ^  ^  ^  ^  ^
+        #
+        # so start by checking them first
+        # this keeps us as fast as possible in failure cases
+        #
+        # (note: "T" and "t" are both allowed under ISO8601)
+        if (
+            date_str[4] != "-"
+            or date_str[7] != "-"
+            or date_str[10] not in ("T", "t")
+            or date_str[13] != ":"
+            or date_str[16] != ":"
+        ):
+            return False
+
+        # check for fractional seconds, which pushes the location of the offset/Z
+        # record the discovered start postiion of the offset segment
+        offset_start = 19
+        if date_str[19] in (".", ","):
+            offset_start = date_str.find("Z", 20)
+            if offset_start == -1:
+                offset_start = date_str.find("z", 20)
+            if offset_start == -1:
+                offset_start = date_str.find("+", 20)
+            if offset_start == -1:
+                offset_start = date_str.find("-", 20)
+            # if we can't find an offset after `.` or `,` as a separator, it's wrong
+            if offset_start == -1:
+                return False
+
+            # fractional seconds are checked to be numeric
+            # the spec seems to allow for any number of digits (?) so there's no
+            # length check here
+            frac_seconds = date_str[20:offset_start]
+            if not frac_seconds:
+                return False
+            if not frac_seconds.isnumeric():
+                return False
+
+        # now, handle Z vs offset
+        # (note: "Z" and "z" are both allowed under ISO8601)
+        z_offset = date_str[offset_start:] in ("Z", "z")
+        if z_offset and len(date_str) != offset_start + 1:
+            return False
+        if not z_offset:
+            if len(date_str) != offset_start + 6:
+                return False
+            if date_str[offset_start] not in ("+", "-"):
+                return False
+            if date_str[offset_start + 3] != ":":
+                return False
+
+        year = date_str[:4]
+        if not year.isnumeric():
+            return False
+        year_val = int(year)
+
+        month = date_str[5:7]
+        if not month.isnumeric():
+            return False
+        month_val = int(month)
+        if not 1 <= month_val <= 12:
+            return False
+
+        day = date_str[8:10]
+        if not day.isnumeric():
+            return False
+        max_day = 31
+        if month_val in (4, 6, 9, 11):
+            max_day = 30
+        elif month_val == 2:
+            max_day = (
+                29
+                if year_val % 4 == 0 and (year_val % 100 != 0 or year_val % 400 == 0)
+                else 28
+            )
+        if not 1 <= int(day) <= max_day:
+            return False
+
+        hour = date_str[11:13]
+        if not hour.isnumeric():
+            return False
+        if not 0 <= int(hour) <= 23:
+            return False
+        minute = date_str[14:16]
+        if not minute.isnumeric():
+            return False
+        if not 0 <= int(minute) <= 59:
+            return False
+        second = date_str[17:19]
+        if not second.isnumeric():
+            return False
+        if not 0 <= int(second) <= 59:
+            return False
+
+        if not z_offset:
+            offset_hour = date_str[offset_start + 1 : offset_start + 3]
+            if not offset_hour.isnumeric():
+                return False
+            if not 0 <= int(offset_hour) <= 23:
+                return False
+            offset_minute = date_str[offset_start + 4 : offset_start + 6]
+            if not offset_minute.isnumeric():
+                return False
+            if not 0 <= int(offset_minute) <= 59:
+                return False
+    except (IndexError, ValueError):
+        return False
+    return True

--- a/src/check_jsonschema/formats/implementations/rfc3339.py
+++ b/src/check_jsonschema/formats/implementations/rfc3339.py
@@ -1,5 +1,4 @@
 import re
-import typing as t
 
 # this regex is based on the one from the rfc3339-validator package
 # credit to the original author
@@ -56,7 +55,7 @@ RFC3339_REGEX = re.compile(
 )
 
 
-def validate(date_str: t.Any) -> bool:
+def validate(date_str: object) -> bool:
     """Validate a string as a RFC3339 date-time."""
     if not isinstance(date_str, str):
         return False
@@ -80,18 +79,15 @@ if __name__ == "__main__":
     import timeit
 
     N = 100_000
-    long_fracsec = "2018-12-31T23:59:59.8446519776713Z"
-    basic = "2018-12-31T23:59:59Z"
-    in_february = "2018-02-12T23:59:59Z"
-    in_february_invalid = "2018-02-29T23:59:59Z"
+    tests = (
+        ("long_fracsec", "2018-12-31T23:59:59.8446519776713Z"),
+        ("basic", "2018-12-31T23:59:59Z"),
+        ("in_february", "2018-02-12T23:59:59Z"),
+        ("in_february_invalid", "2018-02-29T23:59:59Z"),
+    )
 
     print("benchmarking")
-    for name, val in (
-        ("long_fracsec", long_fracsec),
-        ("basic", basic),
-        ("february", in_february),
-        ("february_invalid", in_february_invalid),
-    ):
+    for name, val in tests:
         all_times = timeit.repeat(
             f"validate({val!r})", globals=globals(), repeat=3, number=N
         )

--- a/src/check_jsonschema/formats/implementations/rfc3339.py
+++ b/src/check_jsonschema/formats/implementations/rfc3339.py
@@ -1,118 +1,98 @@
-def validate(date_str: str) -> bool:
-    """Validate a string as a RFC3339 date-time.
+import re
+import typing as t
 
-    This check does the fastest possible validation of the date string (in Python),
-    deferring operations as much as possible to avoid unnecessary work.
-    """
-    try:
-        # the following chars MUST be fixed values:
-        #    YYYY-MM-DDTHH:MM:SSZ
-        #        ^  ^  ^  ^  ^
-        #
-        # so start by checking them first
-        # this keeps us as fast as possible in failure cases
-        #
-        # (note: "T" and "t" are both allowed under ISO8601)
-        if (
-            date_str[4] != "-"
-            or date_str[7] != "-"
-            or date_str[10] not in ("T", "t")
-            or date_str[13] != ":"
-            or date_str[16] != ":"
-        ):
-            return False
+# this regex is based on the one from the rfc3339-validator package
+# credit to the original author
+# original license:
+#
+#    MIT License
+#
+#    Copyright (c) 2019, Nicolas Aimetti
+#
+#    Permission is hereby granted, free of charge, to any person obtaining a copy
+#    of this software and associated documentation files (the "Software"), to deal
+#    in the Software without restriction, including without limitation the rights
+#    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#    copies of the Software, and to permit persons to whom the Software is
+#    furnished to do so, subject to the following conditions:
+#
+#    The above copyright notice and this permission notice shall be included in all
+#    copies or substantial portions of the Software.
+#
+#    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#    SOFTWARE.
+#
+# modifications have been made for additional corner cases and speed
+RFC3339_REGEX = re.compile(
+    r"""
+    ^
+    (?:\d{4})
+    -
+    (?:0[1-9]|1[0-2])
+    -
+    (?:\d{2})
+    (?:T|t)
+    (?:[01]\d|2[0123])
+    :
+    (?:[0-5]\d)
+    :
+    (?:[0-5]\d)
+    # (optional) fractional seconds
+    (?:(\.|,)\d+)?
+    # UTC or offset
+    (?:
+        Z
+        | z
+        | [+-](?:[01]\d|2[0123]):[0-5]\d
+    )
+    $
+""",
+    re.VERBOSE | re.ASCII,
+)
 
-        # check for fractional seconds, which pushes the location of the offset/Z
-        # record the discovered start postiion of the offset segment
-        offset_start = 19
-        if date_str[19] in (".", ","):
-            offset_start = date_str.find("Z", 20)
-            if offset_start == -1:
-                offset_start = date_str.find("z", 20)
-            if offset_start == -1:
-                offset_start = date_str.find("+", 20)
-            if offset_start == -1:
-                offset_start = date_str.find("-", 20)
-            # if we can't find an offset after `.` or `,` as a separator, it's wrong
-            if offset_start == -1:
-                return False
 
-            # fractional seconds are checked to be numeric
-            # the spec seems to allow for any number of digits (?) so there's no
-            # length check here
-            frac_seconds = date_str[20:offset_start]
-            if not frac_seconds:
-                return False
-            if not frac_seconds.isnumeric():
-                return False
+def validate(date_str: t.Any) -> bool:
+    """Validate a string as a RFC3339 date-time."""
+    if not isinstance(date_str, str):
+        return False
+    if not RFC3339_REGEX.match(date_str):
+        return False
 
-        # now, handle Z vs offset
-        # (note: "Z" and "z" are both allowed under ISO8601)
-        z_offset = date_str[offset_start:] in ("Z", "z")
-        if z_offset and len(date_str) != offset_start + 1:
-            return False
-        if not z_offset:
-            if len(date_str) != offset_start + 6:
-                return False
-            if date_str[offset_start] not in ("+", "-"):
-                return False
-            if date_str[offset_start + 3] != ":":
-                return False
+    year, month, day = int(date_str[:4]), int(date_str[5:7]), int(date_str[8:10])
 
-        year = date_str[:4]
-        if not year.isnumeric():
-            return False
-        year_val = int(year)
-
-        month = date_str[5:7]
-        if not month.isnumeric():
-            return False
-        month_val = int(month)
-        if not 1 <= month_val <= 12:
-            return False
-
-        day = date_str[8:10]
-        if not day.isnumeric():
-            return False
+    if month in {4, 6, 9, 11}:
+        max_day = 30
+    elif month == 2:
+        max_day = 29 if year % 4 == 0 and (year % 100 != 0 or year % 400 == 0) else 28
+    else:
         max_day = 31
-        if month_val in (4, 6, 9, 11):
-            max_day = 30
-        elif month_val == 2:
-            max_day = (
-                29
-                if year_val % 4 == 0 and (year_val % 100 != 0 or year_val % 400 == 0)
-                else 28
-            )
-        if not 1 <= int(day) <= max_day:
-            return False
-
-        hour = date_str[11:13]
-        if not hour.isnumeric():
-            return False
-        if not 0 <= int(hour) <= 23:
-            return False
-        minute = date_str[14:16]
-        if not minute.isnumeric():
-            return False
-        if not 0 <= int(minute) <= 59:
-            return False
-        second = date_str[17:19]
-        if not second.isnumeric():
-            return False
-        if not 0 <= int(second) <= 59:
-            return False
-
-        if not z_offset:
-            offset_hour = date_str[offset_start + 1 : offset_start + 3]
-            if not offset_hour.isnumeric():
-                return False
-            if not 0 <= int(offset_hour) <= 23:
-                return False
-            offset_minute = date_str[offset_start + 4 : offset_start + 6]
-            if not offset_minute.isnumeric():
-                return False
-            if not 0 <= int(offset_minute) <= 59:
-                return False
-    except (IndexError, ValueError):
+    if not 1 <= day <= max_day:
         return False
     return True
+
+
+if __name__ == "__main__":
+    import timeit
+
+    N = 100_000
+    long_fracsec = "2018-12-31T23:59:59.8446519776713Z"
+    basic = "2018-12-31T23:59:59Z"
+    in_february = "2018-02-12T23:59:59Z"
+    in_february_invalid = "2018-02-29T23:59:59Z"
+
+    print("benchmarking")
+    for name, val in (
+        ("long_fracsec", long_fracsec),
+        ("basic", basic),
+        ("february", in_february),
+        ("february_invalid", in_february_invalid),
+    ):
+        all_times = timeit.repeat(
+            f"validate({val!r})", globals=globals(), repeat=3, number=N
+        )
+        print(f"{name} (valid={validate(val)}): {int(min(all_times) / N * 10**9)}ns")

--- a/tests/unit/formats/test_rfc3339.py
+++ b/tests/unit/formats/test_rfc3339.py
@@ -1,0 +1,99 @@
+import random
+
+import pytest
+
+from check_jsonschema.formats.implementations.rfc3339 import validate
+
+
+@pytest.mark.parametrize(
+    "datestr",
+    (
+        "2018-12-31T23:59:59Z",
+        "2018-12-31t23:59:59Z",
+        "2018-12-31t23:59:59z",
+        "2018-12-31T23:59:59+00:00",
+        "2018-12-31T23:59:59-00:00",
+    ),
+)
+def test_simple_positive_cases(datestr):
+    assert validate(datestr)
+
+
+@pytest.mark.parametrize(
+    "datestr",
+    (
+        "2018-12-31T23:59:59",
+        "2018-12-31T23:59:59+00:00Z",
+        "2018-12-31 23:59:59",
+    ),
+)
+def test_simple_negative_case(datestr):
+    assert not validate(datestr)
+
+
+@pytest.mark.parametrize("precision", list(range(20)))
+@pytest.mark.parametrize(
+    "offsetstr",
+    (
+        "Z",
+        "+00:00",
+        "-00:00",
+        "+23:59",
+    ),
+)
+def test_allows_fracsec(precision, offsetstr):
+    fracsec = random.randint(0, 10**precision)
+    assert validate(f"2018-12-31T23:59:59.{fracsec}{offsetstr}")
+
+
+@pytest.mark.parametrize(
+    "datestr",
+    (
+        # no such month
+        "2020-13-01T00:00:00Z",
+        "2020-00-01T00:00:00Z",
+        # no such day
+        "2020-01-00T00:00:00Z",
+        "2020-01-32T00:00:00Z",
+    ),
+)
+def test_basic_bounds_validated(datestr):
+    assert not validate(datestr)
+
+
+@pytest.mark.parametrize(
+    "month, maxday",
+    (
+        (1, 31),
+        (3, 31),
+        (4, 30),
+        (5, 31),
+        (6, 30),
+        (7, 31),
+        (8, 31),
+        (9, 30),
+        (10, 31),
+        (11, 30),
+    ),
+)
+def test_day_bounds_by_month(month, maxday):
+    good_date = f"2020-{month:02}-{maxday:02}T00:00:00Z"
+    bad_date = f"2020-{month:02}-{maxday+1:02}T00:00:00Z"
+    assert validate(good_date)
+    assert not validate(bad_date)
+
+
+@pytest.mark.parametrize(
+    "year, maxday",
+    (
+        (2018, 28),
+        (2016, 29),
+        (2400, 29),
+        (2500, 28),
+    ),
+)
+def test_day_bounds_for_february(year, maxday):
+    good_date = f"{year}-02-{maxday:02}T00:00:00Z"
+    bad_date = f"{year}-02-{maxday+1:02}T00:00:00Z"
+    assert validate(good_date)
+    assert not validate(bad_date)

--- a/tests/unit/formats/test_time.py
+++ b/tests/unit/formats/test_time.py
@@ -1,0 +1,47 @@
+import random
+
+import pytest
+
+from check_jsonschema.formats.implementations.iso8601_time import validate
+
+
+@pytest.mark.parametrize(
+    "timestr",
+    (
+        "12:34:56Z",
+        "23:59:59z",
+        "23:59:59+00:00",
+        "01:59:59-00:00",
+    ),
+)
+def test_simple_positive_cases(timestr):
+    assert validate(timestr)
+
+
+@pytest.mark.parametrize(
+    "timestr",
+    (
+        "12:34:56",
+        "23:59:60Z",
+        "23:59:59+24:00",
+        "01:59:59-00:60",
+        "01:01:00:00:60",
+    ),
+)
+def test_simple_negative_cases(timestr):
+    assert not validate(timestr)
+
+
+@pytest.mark.parametrize("precision", list(range(20)))
+@pytest.mark.parametrize(
+    "offsetstr",
+    (
+        "Z",
+        "+00:00",
+        "-00:00",
+        "+23:59",
+    ),
+)
+def test_allows_fracsec(precision, offsetstr):
+    fracsec = random.randint(0, 10**precision)
+    assert validate(f"23:59:59.{fracsec}{offsetstr}")


### PR DESCRIPTION
Add a built-in RFC3339 validator, so that format validation of `date-time` is always available.

Also add a `time` validator (ISO 8601, similar to RFC 3339).