### PR TITLE
Update vendor schemas weekly instead of daily

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -1,8 +1,8 @@
 name: daily
 on:
-  # build every day at 4:00 AM UTC
+  # build on Sunday at 4:00 AM UTC
   schedule:
-    - cron: '0 4 * * *'
+    - cron: '0 4 * * 0'
   workflow_dispatch:
 
 


### PR DESCRIPTION
re: https://github.com/python-jsonschema/check-jsonschema/pull/409#issuecomment-2030480791

Daily is too noisy, dial down to weekly instead.

I arbitrarily went with Sunday, kept it at 4am UTC:

* https://crontab.guru/#0_4_*_*_0

