### PR TITLE
Fix cache handling bug with validation callback

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,9 @@ Unreleased
 ----------
 
 .. vendor-insert-here
+- Fix an ordering bug which caused caching to be ineffective, resulting in
+  repeated downloads of remote schemas even when the cache was populated.
+  Thanks :user:`alex1701c` for reporting! (:issue:`453`)
 
 0.28.6
 ------


### PR DESCRIPTION
The validation_callback invocation in CacheDownloader forced redownloads even on a cache hit, in order to pass the response content to a parser.

After experimenting with several solutions, the easiest is to abstract out `validation_callback` into an arbitrary `response_ok` call which gets passed into the request fetching loop. `response_ok` is then a wrapper over the validation callback which can intentionally answer "yes" eagerly if a response evaluates to a cache hit -- a response which is a '200 Ok' and contains a Last-Modified header which scans as a hit should be treated as 'ok' regardless of its content.

In addition to the code changes, a regression test is included, which is demonstrated to fail on the current release.

resolves #453