### PR TITLE
Cache remote refs when downloading, refactor cachedownloader

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -115,3 +115,46 @@ To resolve, quote the boolean:
 
     steps:
       - bash: echo "{{ parameters.myBoolean}}"
+
+Caching
+-------
+
+What data gets cached?
+~~~~~~~~~~~~~~~~~~~~~~
+
+``check-jsonschema`` will cache all downloaded schemas by default.
+The schemas are stored in the ``downloads/`` directory in your cache dir, and any
+downloaded refs are stored in the ``refs/`` directory.
+
+Where is the cache dir?
+~~~~~~~~~~~~~~~~~~~~~~~
+
+``check-jsonschema`` detects an appropriate cache directory based on your
+platform and environment variables.
+
+On Windows, the cache dir is ``%LOCALAPPDATA%/check_jsonschema/`` and falls back
+to ``%APPDATA%/check_jsonschema/`` if ``LOCALAPPDATA`` is unset.
+
+On macOS, the cache dir is ``~/Library/Caches/check_jsonschema/``.
+
+On Linux, the cache dir is ``$XDG_CACHE_HOME/check_jsonschema/`` and falls back
+to ``~/.cache/check_jsonschema/`` if ``XDG_CACHE_HOME`` is unset.
+
+How does check-jsonschema decide what is a cache hit vs miss?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``check-jsonschema`` checks for cache hits by comparing local file modification
+times to the ``Last-Modified`` header present in the headers on an HTTP GET
+request. If the local last modified time is older than the header, the rest of
+the request will be streamed and written to replace the file.
+
+How do I clear the cache?
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+There is no special command for clearing the cache. Simply find the cache
+directory based on the information above and remove it or any of its contents.
+
+Can I disable caching?
+~~~~~~~~~~~~~~~~~~~~~~
+
+Yes! Just use the ``--no-cache`` CLI option.

--- a/src/check_jsonschema/cachedownloader.py
+++ b/src/check_jsonschema/cachedownloader.py
@@ -11,102 +11,101 @@ import typing as t
 
 import requests
 
+# this will let us do any other caching we might need in the future in the same
+# cache dir (adjacent to "downloads")
+_CACHEDIR_NAME = os.path.join("check_jsonschema", "downloads")
+
+_LASTMOD_FMT = "%a, %d %b %Y %H:%M:%S %Z"
+
+
+def _get_default_cache_dir() -> str | None:
+    sysname = platform.system()
+
+    # on windows, try to get the appdata env var
+    # this *could* result in cache_dir=None, which is fine, just skip caching in
+    # that case
+    if sysname == "Windows":
+        cache_dir = os.getenv("LOCALAPPDATA", os.getenv("APPDATA"))
+    # macOS -> app support dir
+    elif sysname == "Darwin":
+        cache_dir = os.path.expanduser("~/Library/Caches")
+    # default for unknown platforms, namely linux behavior
+    # use XDG env var and default to ~/.cache/
+    else:
+        cache_dir = os.getenv("XDG_CACHE_HOME", os.path.expanduser("~/.cache"))
+
+    if cache_dir:
+        cache_dir = os.path.join(cache_dir, _CACHEDIR_NAME)
+
+    return cache_dir
+
+
+def _lastmod_from_response(response: requests.Response) -> float:
+    try:
+        return time.mktime(
+            time.strptime(response.headers["last-modified"], _LASTMOD_FMT)
+        )
+    # OverflowError: time outside of platform-specific bounds
+    # ValueError: malformed/unparseable
+    # LookupError: no such header
+    except (OverflowError, ValueError, LookupError):
+        return 0.0
+
+
+def _get_request(
+    file_url: str, *, response_ok: t.Callable[[requests.Response], bool]
+) -> requests.Response:
+    try:
+        r: requests.Response | None = None
+        for _attempt in range(3):
+            r = requests.get(file_url, stream=True)
+            if r.ok and response_ok(r):
+                return r
+        assert r is not None
+        raise FailedDownloadError(
+            f"got response with status={r.status_code}, retries exhausted"
+        )
+    except requests.RequestException as e:
+        raise FailedDownloadError("encountered error during download") from e
+
+
+def _atomic_write(dest: str, content: bytes) -> None:
+    # download to a temp file and then move to the dest
+    # this makes the download safe if run in parallel (parallel runs
+    # won't create a new empty file for writing and cause failures)
+    fp = tempfile.NamedTemporaryFile(mode="wb", delete=False)
+    fp.write(content)
+    fp.close()
+    shutil.copy(fp.name, dest)
+    os.remove(fp.name)
+
+
+def _cache_hit(cachefile: str, response: requests.Response) -> bool:
+    # no file? miss
+    if not os.path.exists(cachefile):
+        return False
+
+    # compare mtime on any cached file against the remote last-modified time
+    # it is considered a hit if the local file is at least as new as the remote file
+    local_mtime = os.path.getmtime(cachefile)
+    remote_mtime = _lastmod_from_response(response)
+    return local_mtime >= remote_mtime
+
 
 class FailedDownloadError(Exception):
     pass
 
 
 class CacheDownloader:
-    _LASTMOD_FMT = "%a, %d %b %Y %H:%M:%S %Z"
-
-    # changed in v0.5.0
-    # original cache dir was "jsonschema_validate"
-    # this will let us do any other caching we might need in the future in the same
-    # cache dir (adjacent to "downloads")
-    _CACHEDIR_NAME = os.path.join("check_jsonschema", "downloads")
-
     def __init__(
         self,
-        file_url: str,
-        filename: str | None = None,
         cache_dir: str | None = None,
         disable_cache: bool = False,
         validation_callback: t.Callable[[bytes], t.Any] | None = None,
     ):
-        self._file_url = file_url
-        self._filename = filename or file_url.split("/")[-1]
-        self._cache_dir = cache_dir or self._compute_default_cache_dir()
+        self._cache_dir = cache_dir or _get_default_cache_dir()
         self._disable_cache = disable_cache
         self._validation_callback = validation_callback
-
-    def _compute_default_cache_dir(self) -> str | None:
-        sysname = platform.system()
-
-        # on windows, try to get the appdata env var
-        # this *could* result in cache_dir=None, which is fine, just skip caching in
-        # that case
-        if sysname == "Windows":
-            cache_dir = os.getenv("LOCALAPPDATA", os.getenv("APPDATA"))
-        # macOS -> app support dir
-        elif sysname == "Darwin":
-            cache_dir = os.path.expanduser("~/Library/Caches")
-        # default for unknown platforms, namely linux behavior
-        # use XDG env var and default to ~/.cache/
-        else:
-            cache_dir = os.getenv("XDG_CACHE_HOME", os.path.expanduser("~/.cache"))
-
-        if cache_dir:
-            cache_dir = os.path.join(cache_dir, self._CACHEDIR_NAME)
-
-        return cache_dir
-
-    def _get_request(
-        self, *, response_ok: t.Callable[[requests.Response], bool]
-    ) -> requests.Response:
-        try:
-            r: requests.Response | None = None
-            for _attempt in range(3):
-                r = requests.get(self._file_url, stream=True)
-                if r.ok and response_ok(r):
-                    return r
-            assert r is not None
-            raise FailedDownloadError(
-                f"got response with status={r.status_code}, retries exhausted"
-            )
-        except requests.RequestException as e:
-            raise FailedDownloadError("encountered error during download") from e
-
-    def _lastmod_from_response(self, response: requests.Response) -> float:
-        try:
-            return time.mktime(
-                time.strptime(response.headers["last-modified"], self._LASTMOD_FMT)
-            )
-        # OverflowError: time outside of platform-specific bounds
-        # ValueError: malformed/unparseable
-        # LookupError: no such header
-        except (OverflowError, ValueError, LookupError):
-            return 0.0
-
-    def _cache_hit(self, cachefile: str, response: requests.Response) -> bool:
-        # no file? miss
-        if not os.path.exists(cachefile):
-            return False
-
-        # compare mtime on any cached file against the remote last-modified time
-        # it is considered a hit if the local file is at least as new as the remote file
-        local_mtime = os.path.getmtime(cachefile)
-        remote_mtime = self._lastmod_from_response(response)
-        return local_mtime >= remote_mtime
-
-    def _write(self, dest: str, response: requests.Response) -> None:
-        # download to a temp file and then move to the dest
-        # this makes the download safe if run in parallel (parallel runs
-        # won't create a new empty file for writing and cause failures)
-        fp = tempfile.NamedTemporaryFile(mode="wb", delete=False)
-        fp.write(response.content)
-        fp.close()
-        shutil.copy(fp.name, dest)
-        os.remove(fp.name)
 
     def _validate(self, response: requests.Response) -> bool:
         if not self._validation_callback:
@@ -118,32 +117,52 @@ class CacheDownloader:
         except ValueError:
             return False
 
-    def _download(self) -> str:
-        assert self._cache_dir
+    def _download(self, file_url: str, filename: str) -> str:
+        assert self._cache_dir is not None
         os.makedirs(self._cache_dir, exist_ok=True)
-        dest = os.path.join(self._cache_dir, self._filename)
+        dest = os.path.join(self._cache_dir, filename)
 
         def check_response_for_download(r: requests.Response) -> bool:
             # if the response indicates a cache hit, treat it as valid
             # this ensures that we short-circuit any further evaluation immediately on
             # a hit
-            if self._cache_hit(dest, r):
+            if _cache_hit(dest, r):
                 return True
             # we now know it's not a hit, so validate the content (forces download)
             return self._validate(r)
 
-        response = self._get_request(response_ok=check_response_for_download)
+        response = _get_request(file_url, response_ok=check_response_for_download)
         # check to see if we have a file which matches the connection
         # only download if we do not (cache miss, vs hit)
-        if not self._cache_hit(dest, response):
-            self._write(dest, response)
+        if not _cache_hit(dest, response):
+            _atomic_write(dest, response.content)
 
         return dest
 
     @contextlib.contextmanager
-    def open(self) -> t.Iterator[t.IO[bytes]]:
+    def open(self, file_url: str, filename: str) -> t.Iterator[t.IO[bytes]]:
         if (not self._cache_dir) or self._disable_cache:
-            yield io.BytesIO(self._get_request(response_ok=self._validate).content)
+            yield io.BytesIO(_get_request(file_url, response_ok=self._validate).content)
         else:
-            with open(self._download(), "rb") as fp:
+            with open(self._download(file_url, filename), "rb") as fp:
                 yield fp
+
+    def bind(self, file_url: str, filename: str | None = None) -> BoundCacheDownloader:
+        return BoundCacheDownloader(file_url, filename, self)
+
+
+class BoundCacheDownloader:
+    def __init__(
+        self,
+        file_url: str,
+        filename: str | None,
+        downloader: CacheDownloader,
+    ):
+        self._file_url = file_url
+        self._filename = filename or file_url.split("/")[-1]
+        self._downloader = downloader
+
+    @contextlib.contextmanager
+    def open(self) -> t.Iterator[t.IO[bytes]]:
+        with self._downloader.open(self._file_url, self._filename) as fp:
+            yield fp

--- a/src/check_jsonschema/cli/main_command.py
+++ b/src/check_jsonschema/cli/main_command.py
@@ -300,8 +300,8 @@ def build_schema_loader(args: ParseResult) -> SchemaLoaderBase:
         assert args.schema_path is not None
         return SchemaLoader(
             args.schema_path,
-            args.cache_filename,
-            args.disable_cache,
+            cache_filename=args.cache_filename,
+            disable_cache=args.disable_cache,
             base_uri=args.base_uri,
             validator_class=args.validator_class,
         )

--- a/src/check_jsonschema/schema_loader/main.py
+++ b/src/check_jsonschema/schema_loader/main.py
@@ -57,14 +57,16 @@ class SchemaLoaderBase:
 
 class SchemaLoader(SchemaLoaderBase):
     validator_class: type[jsonschema.protocols.Validator] | None = None
+    disable_cache: bool = True
 
     def __init__(
         self,
         schemafile: str,
+        *,
         cache_filename: str | None = None,
-        disable_cache: bool = False,
         base_uri: str | None = None,
         validator_class: type[jsonschema.protocols.Validator] | None = None,
+        disable_cache: bool = True,
     ) -> None:
         # record input parameters (these are not to be modified)
         self.schemafile = schemafile
@@ -140,7 +142,7 @@ class SchemaLoader(SchemaLoaderBase):
         # reference resolution
         # with support for YAML, TOML, and other formats from the parsers
         reference_registry = make_reference_registry(
-            self._parsers, retrieval_uri, schema
+            self._parsers, retrieval_uri, schema, self.disable_cache
         )
 
         if self.validator_class is None:
@@ -171,7 +173,7 @@ class SchemaLoader(SchemaLoaderBase):
 
 
 class BuiltinSchemaLoader(SchemaLoader):
-    def __init__(self, schema_name: str, base_uri: str | None = None) -> None:
+    def __init__(self, schema_name: str, *, base_uri: str | None = None) -> None:
         self.schema_name = schema_name
         self.base_uri = base_uri
         self._parsers = ParserSet()
@@ -187,7 +189,7 @@ class BuiltinSchemaLoader(SchemaLoader):
 
 
 class MetaSchemaLoader(SchemaLoaderBase):
-    def __init__(self, base_uri: str | None = None) -> None:
+    def __init__(self, *, base_uri: str | None = None) -> None:
         if base_uri is not None:
             raise NotImplementedError(
                 "'--base-uri' was used with '--metaschema'. "

--- a/src/check_jsonschema/schema_loader/readers.py
+++ b/src/check_jsonschema/schema_loader/readers.py
@@ -79,11 +79,9 @@ class HttpSchemaReader:
         self.url = url
         self.parsers = ParserSet()
         self.downloader = CacheDownloader(
-            url,
-            cache_filename,
             disable_cache=disable_cache,
             validation_callback=self._parse,
-        )
+        ).bind(url, cache_filename)
         self._parsed_schema: dict | _UnsetType = _UNSET
 
     def _parse(self, schema_bytes: bytes) -> t.Any:

--- a/src/check_jsonschema/schema_loader/readers.py
+++ b/src/check_jsonschema/schema_loader/readers.py
@@ -80,8 +80,7 @@ class HttpSchemaReader:
         self.parsers = ParserSet()
         self.downloader = CacheDownloader(
             disable_cache=disable_cache,
-            validation_callback=self._parse,
-        ).bind(url, cache_filename)
+        ).bind(url, cache_filename, validation_callback=self._parse)
         self._parsed_schema: dict | _UnsetType = _UNSET
 
     def _parse(self, schema_bytes: bytes) -> t.Any:

--- a/tests/acceptance/test_nonjson_schema_handling.py
+++ b/tests/acceptance/test_nonjson_schema_handling.py
@@ -1,8 +1,10 @@
 import json
 
 import pytest
+import responses
 
 from check_jsonschema.parsers.json5 import ENABLED as JSON5_ENABLED
+from check_jsonschema.schema_loader.resolver import ref_url_to_cache_filename
 
 SIMPLE_SCHEMA = {
     "$schema": "http://json-schema.org/draft-07/schema",
@@ -87,3 +89,79 @@ def test_can_load_json5_schema(run_line, tmp_path, passing_data):
         ["check-jsonschema", "--schemafile", str(main_schemafile), str(doc)]
     )
     assert result.exit_code == (0 if passing_data else 1)
+
+
+@pytest.mark.parametrize("passing_data", [True, False])
+def test_can_load_remote_yaml_schema(run_line, tmp_path, passing_data):
+    retrieval_uri = "https://example.org/retrieval/schemas/main.yaml"
+    responses.add(
+        "GET",
+        retrieval_uri,
+        body="""\
+"$schema": "http://json-schema.org/draft-07/schema"
+properties:
+  title: {"type": "string"}
+additionalProperties: false
+""",
+    )
+
+    doc = tmp_path / "doc.json"
+    doc.write_text(json.dumps(PASSING_DOCUMENT if passing_data else FAILING_DOCUMENT))
+
+    result = run_line(["check-jsonschema", "--schemafile", retrieval_uri, str(doc)])
+    assert result.exit_code == (0 if passing_data else 1)
+
+
+@pytest.mark.parametrize("passing_data", [True, False])
+def test_can_load_remote_yaml_schema_ref(run_line, tmp_path, passing_data):
+    retrieval_uri = "https://example.org/retrieval/schemas/main.yaml"
+    responses.add(
+        "GET",
+        retrieval_uri,
+        body="""\
+"$schema": "http://json-schema.org/draft-07/schema"
+properties:
+  "title": {"$ref": "./title_schema.yaml"}
+additionalProperties: false
+""",
+    )
+    responses.add(
+        "GET",
+        "https://example.org/retrieval/schemas/title_schema.yaml",
+        body="type: string",
+    )
+
+    doc = tmp_path / "doc.json"
+    doc.write_text(json.dumps(PASSING_DOCUMENT if passing_data else FAILING_DOCUMENT))
+
+    result = run_line(["check-jsonschema", "--schemafile", retrieval_uri, str(doc)])
+    assert result.exit_code == (0 if passing_data else 1)
+
+
+def test_can_load_remote_yaml_schema_ref_from_cache(run_line, cache_dir, tmp_path):
+    retrieval_uri = "https://example.org/retrieval/schemas/main.yaml"
+    responses.add(
+        "GET",
+        retrieval_uri,
+        body="""\
+"$schema": "http://json-schema.org/draft-07/schema"
+properties:
+  "title": {"$ref": "./title_schema.yaml"}
+additionalProperties: false
+""",
+    )
+
+    ref_loc = "https://example.org/retrieval/schemas/title_schema.yaml"
+    # populate a bad schema, but then "override" that with a good cache value
+    # this can only pass (in the success case) if the cache loading really works
+    responses.add("GET", ref_loc, body="false")
+    ref_cache_dir = cache_dir / "check_jsonschema" / "refs"
+    ref_cache_dir.mkdir(parents=True)
+    ref_path = ref_cache_dir / ref_url_to_cache_filename(ref_loc)
+    ref_path.write_text("type: string")
+
+    doc = tmp_path / "doc.json"
+    doc.write_text(json.dumps(PASSING_DOCUMENT))
+
+    result = run_line(["check-jsonschema", "--schemafile", retrieval_uri, str(doc)])
+    assert result.exit_code == 0

--- a/tests/acceptance/test_remote_ref_resolution.py
+++ b/tests/acceptance/test_remote_ref_resolution.py
@@ -3,8 +3,6 @@ import json
 import pytest
 import responses
 
-from check_jsonschema import cachedownloader
-
 CASES = {
     "case1": {
         "main_schema": {
@@ -39,13 +37,12 @@ CASES = {
 
 @pytest.fixture(autouse=True)
 def _mock_schema_cache_dir(monkeypatch, tmp_path):
-    def _fake_compute_default_cache_dir(self):
+    def _fake_default_cache_dir():
         return str(tmp_path)
 
     monkeypatch.setattr(
-        cachedownloader.CacheDownloader,
-        "_compute_default_cache_dir",
-        _fake_compute_default_cache_dir,
+        "check_jsonschema.cachedownloader._get_default_cache_dir",
+        _fake_default_cache_dir,
     )
 
 

--- a/tests/acceptance/test_remote_ref_resolution.py
+++ b/tests/acceptance/test_remote_ref_resolution.py
@@ -1,8 +1,9 @@
-import hashlib
 import json
 
 import pytest
 import responses
+
+from check_jsonschema.schema_loader.resolver import ref_url_to_cache_filename
 
 CASES = {
     "case1": {
@@ -34,10 +35,6 @@ CASES = {
         "failing_document": {"test": {"foo": "bar"}},
     },
 }
-
-
-def _md5(s):
-    return hashlib.md5(s.encode()).hexdigest()
 
 
 @pytest.mark.parametrize("check_passes", (True, False))
@@ -95,7 +92,9 @@ def test_remote_ref_resolution_cache_control(
 
     cache_locs = []
     for ref_loc in ref_locs:
-        cache_locs.append(cache_dir / "check_jsonschema" / "refs" / _md5(ref_loc))
+        cache_locs.append(
+            cache_dir / "check_jsonschema" / "refs" / ref_url_to_cache_filename(ref_loc)
+        )
     assert cache_locs  # sanity check
     if disable_cache:
         for loc in cache_locs:
@@ -126,7 +125,7 @@ def test_remote_ref_resolution_loads_from_cache(
         ref_locs.append(other_schema_loc)
 
         # but populate the cache with "good data"
-        cache_loc = ref_cache_dir / _md5(other_schema_loc)
+        cache_loc = ref_cache_dir / ref_url_to_cache_filename(other_schema_loc)
         cache_locs.append(cache_loc)
         cache_loc.write_text(json.dumps(subschema))
 

--- a/tests/acceptance/test_remote_ref_resolution.py
+++ b/tests/acceptance/test_remote_ref_resolution.py
@@ -35,17 +35,6 @@ CASES = {
 }
 
 
-@pytest.fixture(autouse=True)
-def _mock_schema_cache_dir(monkeypatch, tmp_path):
-    def _fake_default_cache_dir():
-        return str(tmp_path)
-
-    monkeypatch.setattr(
-        "check_jsonschema.cachedownloader._get_default_cache_dir",
-        _fake_default_cache_dir,
-    )
-
-
 @pytest.mark.parametrize("check_passes", (True, False))
 @pytest.mark.parametrize("casename", ("case1", "case2"))
 def test_remote_ref_resolution_simple_case(run_line, check_passes, casename, tmp_path):

--- a/tests/acceptance/test_remote_ref_resolution.py
+++ b/tests/acceptance/test_remote_ref_resolution.py
@@ -3,8 +3,6 @@ import json
 import pytest
 import responses
 
-from check_jsonschema.schema_loader.resolver import ref_url_to_cache_filename
-
 CASES = {
     "case1": {
         "main_schema": {
@@ -68,7 +66,7 @@ def test_remote_ref_resolution_simple_case(run_line, check_passes, casename, tmp
 @pytest.mark.parametrize("casename", ("case1", "case2"))
 @pytest.mark.parametrize("disable_cache", (True, False))
 def test_remote_ref_resolution_cache_control(
-    run_line, tmp_path, cache_dir, casename, disable_cache
+    run_line, tmp_path, get_ref_cache_loc, casename, disable_cache
 ):
     main_schema_loc = "https://example.com/main.json"
     responses.add("GET", main_schema_loc, json=CASES[casename]["main_schema"])
@@ -92,9 +90,7 @@ def test_remote_ref_resolution_cache_control(
 
     cache_locs = []
     for ref_loc in ref_locs:
-        cache_locs.append(
-            cache_dir / "check_jsonschema" / "refs" / ref_url_to_cache_filename(ref_loc)
-        )
+        cache_locs.append(get_ref_cache_loc(ref_loc))
     assert cache_locs  # sanity check
     if disable_cache:
         for loc in cache_locs:
@@ -107,14 +103,10 @@ def test_remote_ref_resolution_cache_control(
 @pytest.mark.parametrize("casename", ("case1", "case2"))
 @pytest.mark.parametrize("check_passes", (True, False))
 def test_remote_ref_resolution_loads_from_cache(
-    run_line, tmp_path, cache_dir, casename, check_passes
+    run_line, tmp_path, get_ref_cache_loc, inject_cached_ref, casename, check_passes
 ):
     main_schema_loc = "https://example.com/main.json"
     responses.add("GET", main_schema_loc, json=CASES[casename]["main_schema"])
-
-    # ensure the ref cache dir exists
-    ref_cache_dir = cache_loc = cache_dir / "check_jsonschema" / "refs"
-    ref_cache_dir.mkdir(parents=True)
 
     ref_locs = []
     cache_locs = []
@@ -125,9 +117,8 @@ def test_remote_ref_resolution_loads_from_cache(
         ref_locs.append(other_schema_loc)
 
         # but populate the cache with "good data"
-        cache_loc = ref_cache_dir / ref_url_to_cache_filename(other_schema_loc)
-        cache_locs.append(cache_loc)
-        cache_loc.write_text(json.dumps(subschema))
+        inject_cached_ref(other_schema_loc, json.dumps(subschema))
+        cache_locs.append(get_ref_cache_loc(other_schema_loc))
 
     instance_path = tmp_path / "instance.json"
     instance_path.write_text(

--- a/tests/acceptance/test_special_filetypes.py
+++ b/tests/acceptance/test_special_filetypes.py
@@ -6,8 +6,6 @@ import sys
 import pytest
 import responses
 
-from check_jsonschema import cachedownloader
-
 
 @pytest.mark.skipif(
     platform.system() != "Linux", reason="test requires /proc/self/ mechanism"
@@ -87,13 +85,12 @@ def test_remote_schema_requiring_retry(run_line, check_passes, tmp_path, monkeyp
     fires in order to parse
     """
 
-    def _fake_compute_default_cache_dir(self):
+    def _fake_default_cache_dir():
         return str(tmp_path)
 
     monkeypatch.setattr(
-        cachedownloader.CacheDownloader,
-        "_compute_default_cache_dir",
-        _fake_compute_default_cache_dir,
+        "check_jsonschema.cachedownloader._get_default_cache_dir",
+        _fake_default_cache_dir,
     )
 
     schema_loc = "https://example.com/schema1.json"

--- a/tests/acceptance/test_special_filetypes.py
+++ b/tests/acceptance/test_special_filetypes.py
@@ -79,20 +79,11 @@ def test_schema_and_instance_in_fifos(tmp_path, run_line, check_succeeds):
 
 
 @pytest.mark.parametrize("check_passes", (True, False))
-def test_remote_schema_requiring_retry(run_line, check_passes, tmp_path, monkeypatch):
+def test_remote_schema_requiring_retry(run_line, check_passes, tmp_path):
     """
     a "remote schema" (meaning HTTPS) with bad data, therefore requiring that a retry
     fires in order to parse
     """
-
-    def _fake_default_cache_dir():
-        return str(tmp_path)
-
-    monkeypatch.setattr(
-        "check_jsonschema.cachedownloader._get_default_cache_dir",
-        _fake_default_cache_dir,
-    )
-
     schema_loc = "https://example.com/schema1.json"
     responses.add("GET", schema_loc, body="", match_querystring=None)
     responses.add(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,3 +60,53 @@ def patch_cache_dir(monkeypatch, cache_dir):
             "check_jsonschema.cachedownloader._base_cache_dir", lambda: str(cache_dir)
         )
         yield m
+
+
+@pytest.fixture
+def downloads_cache_dir(tmp_path):
+    return tmp_path / ".cache" / "check_jsonschema" / "downloads"
+
+
+@pytest.fixture
+def get_download_cache_loc(downloads_cache_dir):
+    def _get(uri):
+        return downloads_cache_dir / uri.split("/")[-1]
+
+    return _get
+
+
+@pytest.fixture
+def inject_cached_download(downloads_cache_dir, get_download_cache_loc):
+    def _write(uri, content):
+        downloads_cache_dir.mkdir(parents=True)
+        path = get_download_cache_loc(uri)
+        if isinstance(content, str):
+            path.write_text(content)
+        else:
+            path.write_bytes(content)
+
+    return _write
+
+
+@pytest.fixture
+def refs_cache_dir(tmp_path):
+    return tmp_path / ".cache" / "check_jsonschema" / "refs"
+
+
+@pytest.fixture
+def get_ref_cache_loc(refs_cache_dir):
+    from check_jsonschema.schema_loader.resolver import ref_url_to_cache_filename
+
+    def _get(uri):
+        return refs_cache_dir / ref_url_to_cache_filename(uri)
+
+    return _get
+
+
+@pytest.fixture
+def inject_cached_ref(refs_cache_dir, get_ref_cache_loc):
+    def _write(uri, content):
+        refs_cache_dir.mkdir(parents=True)
+        get_ref_cache_loc(uri).write_text(content)
+
+    return _write

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,3 +46,17 @@ def in_tmp_dir(request, tmp_path):
     os.chdir(str(tmp_path))
     yield
     os.chdir(request.config.invocation_dir)
+
+
+@pytest.fixture
+def cache_dir(tmp_path):
+    return tmp_path / ".cache"
+
+
+@pytest.fixture(autouse=True)
+def patch_cache_dir(monkeypatch, cache_dir):
+    with monkeypatch.context() as m:
+        m.setattr(
+            "check_jsonschema.cachedownloader._base_cache_dir", lambda: str(cache_dir)
+        )
+        yield m


### PR DESCRIPTION
Resolves #452.

- Refactor the cachedownloader to bound/unbound
- Expand caching to cache remote refs
- Add tests for ref resolution on-disk caching
- Preserve extension on cached refs
- Add FAQ docs on caching
