### PR TITLE
Update `cron` workflow `name`

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -1,4 +1,4 @@
-name: daily
+name: weekly
 on:
   # build on Sunday at 4:00 AM UTC
   schedule:


### PR DESCRIPTION
It looks like 845f8e5de51364145361f3e04e4fb82d6da2d83a changed `cron.yaml` to run weekly instead of daily, but the `name` of the workflow was left as `daily`. This just updates the `name`. 

(Or perhaps the `name` should be something like `scheduled-schema-update`?)