### PR TITLE
Don't pass `-v` to pytest in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -97,7 +97,7 @@ jobs:
 
       - name: test
         run: |
-          python -m tox run -m ci -- -v --junitxml pytest.{envname}.xml
+          python -m tox run -m ci -- --junitxml pytest.{envname}.xml
           python -m tox run -e cov
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
This makes the output simply too verbose.
