### PR TITLE
Update supported Python range to 3.9-3.13

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
         py: ["3.x"]
         include:
           - toxenv: py-mindeps
-            py: "3.8"
+            py: "3.9"
 
     runs-on: ubuntu-latest
     name: "Run '${{ matrix.toxenv }}' on python ${{ matrix.py }}"
@@ -62,7 +62,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        py: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        py: ['3.9', '3.10', '3.11', '3.12', '3.13']
     name: "Run tests on ${{ matrix.os }}, py${{ matrix.py }}"
     runs-on: ${{ matrix.os }}
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,4 +42,4 @@ repos:
   rev: v3.19.1
   hooks:
     - id: pyupgrade
-      args: ["--py37-plus"]
+      args: ["--py39-plus"]

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,9 +4,9 @@ sphinx:
   configuration: docs/conf.py
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: "3.10"
+    python: "3.13"
 
 python:
   install:
@@ -14,4 +14,3 @@ python:
       path: .
       extra_requirements:
         - docs
-

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Unreleased
 .. vendor-insert-here
 
 - Update vendored schemas (2024-12-22)
+- Drop support for Python 3.8
 
 0.30.0
 ------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,8 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
-    'importlib-resources>=1.4.0;python_version<"3.9"',
     'tomli>=2.0;python_version<"3.11"',
     "ruamel.yaml==0.18.6",
     "jsonschema>=4.18.0,<5.0",

--- a/src/check_jsonschema/builtin_schemas/__init__.py
+++ b/src/check_jsonschema/builtin_schemas/__init__.py
@@ -1,12 +1,6 @@
 from __future__ import annotations
 
-try:
-    # first, try to import the installed package version
-    import importlib_resources
-except ImportError:
-    # if it's not installed, assume that the stdlib version is new enough (e.g. py3.10)
-    import importlib.resources as importlib_resources  # type: ignore[no-redef]
-
+import importlib.resources
 import json
 import typing as t
 
@@ -20,7 +14,7 @@ def _get(package: str, resource: str, name: str) -> dict[str, t.Any]:
         return t.cast(
             "dict[str, t.Any]",
             json.loads(
-                importlib_resources.files(package).joinpath(resource).read_bytes()
+                importlib.resources.files(package).joinpath(resource).read_bytes()
             ),
         )
     except (FileNotFoundError, ModuleNotFoundError):

--- a/src/check_jsonschema/cli/main_command.py
+++ b/src/check_jsonschema/cli/main_command.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import sys
 import textwrap
 import typing as t
 
@@ -23,11 +22,6 @@ from ..schema_loader import (
 from ..transforms import TRANSFORM_LIBRARY
 from .param_types import CommaDelimitedList, LazyBinaryReadFile, ValidatorClassName
 from .parse_result import ParseResult, SchemaLoadingMode
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 BUILTIN_SCHEMA_NAMES = [f"vendor.{k}" for k in SCHEMA_CATALOG.keys()] + [
     f"custom.{k}" for k in CUSTOM_SCHEMA_NAMES
@@ -236,13 +230,13 @@ def main(
     no_cache: bool,
     cache_filename: str | None,
     disable_formats: tuple[list[str], ...],
-    format_regex: Literal["python", "default"],
-    default_filetype: Literal["json", "yaml", "toml", "json5"],
-    traceback_mode: Literal["full", "short"],
-    data_transform: Literal["azure-pipelines", "gitlab-ci"] | None,
+    format_regex: t.Literal["python", "default"],
+    default_filetype: t.Literal["json", "yaml", "toml", "json5"],
+    traceback_mode: t.Literal["full", "short"],
+    data_transform: t.Literal["azure-pipelines", "gitlab-ci"] | None,
     fill_defaults: bool,
     validator_class: type[jsonschema.protocols.Validator] | None,
-    output_format: Literal["text", "json"],
+    output_format: t.Literal["text", "json"],
     verbose: int,
     quiet: int,
     instancefiles: tuple[t.IO[bytes], ...],

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,10 @@
 envlist =
     mypy
     cov_clean
-    py38-mindeps{,-format}
-    py{312,311,310,39,38}
-    py{38,312}-{json5,pyjson5}{,-format}
-    py{38,312}-{disable_orjson}
+    py39-mindeps{,-format}
+    py{313,312,311,310,39}
+    py{39,313}-{json5,pyjson5}{,-format}
+    py{39,313}-{disable_orjson}
     cov
 skip_missing_interpreters = true
 minversion = 4.0.0
@@ -24,7 +24,6 @@ deps =
     mindeps: jsonschema==4.18.0
     mindeps: click==8.0.0
     mindeps: requests==2.0.0
-    mindeps: importlib-resources==1.4.0
     !disable_orjson: orjson
     json5: json5
     pyjson5: pyjson5


### PR DESCRIPTION
- Update the lower bound from 3.8 to 3.9
- Update the highest tested version from 3.12 to 3.13
- Remove importlib-resources dependency (for <3.9)
