### PR TITLE
Update ruamel.yaml from pin to bounds

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Unreleased
 - Update the ``gitlab`` and ``renovate`` hooks to use
   ``--regex-variant nonunicode``. Thanks :user:`quentin-ag` and :user:`Callek`
   for reporting! (:issue:`516`, :issue:`518`)
+- Update the required ``ruamel.yaml`` version to a range,
+  ``>=0.18.10,<0.19.0``.
 
 0.31.0
 ------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     'tomli>=2.0;python_version<"3.11"',
-    "ruamel.yaml==0.18.7",
+    "ruamel.yaml>=0.18.10,<0.19.0",
     "jsonschema>=4.18.0,<5.0",
     "regress>=2024.11.1",
     "requests<3.0",


### PR DESCRIPTION
This achieves two things. First, it gets us onto the latest version
(as of today), and second it resolves any complaint that the pin is
too restrictive for users.
