### PR TITLE
Replace flake8 with ruff for linting and code style enforcement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,14 +27,11 @@ repos:
   rev: 25.1.0
   hooks:
     - id: black
-- repo: https://github.com/PyCQA/flake8
-  rev: 7.2.0
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.5.5
   hooks:
-    - id: flake8
-      additional_dependencies:
-        - 'flake8-bugbear==24.4.26'
-        - 'flake8-typing-as-t==0.0.3'
-        - 'flake8-comprehensions==3.15.0'
+    - id: ruff
+      args: ["--fix"]
 - repo: https://github.com/sirosen/slyp
   rev: 0.8.2
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,13 @@ namespaces = false
 [tool.isort]
 profile = "black"
 
+[tool.ruff]
+select = [
+    "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "TYP", # flake8-typing-as-t
+]
+
 [tool.mypy]
 # strict = true  # TODO: enable
 disallow_untyped_defs = true

--- a/src/check_jsonschema/builtin_schemas/__init__.py
+++ b/src/check_jsonschema/builtin_schemas/__init__.py
@@ -17,8 +17,8 @@ def _get(package: str, resource: str, name: str) -> dict[str, t.Any]:
                 importlib.resources.files(package).joinpath(resource).read_bytes()
             ),
         )
-    except (FileNotFoundError, ModuleNotFoundError):
-        raise NoSuchSchemaError(f"no builtin schema named {name} was found")
+    except (FileNotFoundError, ModuleNotFoundError) as err:
+        raise NoSuchSchemaError(f"no builtin schema named {name} was found") from err
 
 
 def _get_vendored_schema(name: str) -> dict[str, t.Any]:

--- a/src/check_jsonschema/checker.py
+++ b/src/check_jsonschema/checker.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import pathlib
 import typing as t
 
 import click
@@ -8,11 +7,7 @@ import jsonschema
 import referencing.exceptions
 
 from . import utils
-from .formats import FormatOptions
-from .instance_loader import InstanceLoader
 from .parsers import ParseError
-from .regex_variants import RegexImplementation
-from .reporter import Reporter
 from .result import CheckResult
 from .schema_loader import SchemaLoaderBase, SchemaParseError, UnsupportedUrlScheme
 
@@ -20,6 +15,15 @@ from .schema_loader import SchemaLoaderBase, SchemaParseError, UnsupportedUrlSch
 class _Exit(Exception):
     def __init__(self, code: int) -> None:
         self.code = code
+
+
+if t.TYPE_CHECKING:
+    import pathlib
+
+    from .formats import FormatOptions
+    from .instance_loader import InstanceLoader
+    from .regex_variants import RegexImplementation
+    from .reporter import Reporter
 
 
 class SchemaChecker:

--- a/src/check_jsonschema/cli/main_command.py
+++ b/src/check_jsonschema/cli/main_command.py
@@ -5,7 +5,6 @@ import textwrap
 import typing as t
 
 import click
-import jsonschema
 
 from ..catalog import CUSTOM_SCHEMA_NAMES, SCHEMA_CATALOG
 from ..checker import SchemaChecker
@@ -30,6 +29,9 @@ BUILTIN_SCHEMA_NAMES = [f"vendor.{k}" for k in SCHEMA_CATALOG.keys()] + [
 BUILTIN_SCHEMA_CHOICES = (
     BUILTIN_SCHEMA_NAMES + list(SCHEMA_CATALOG.keys()) + CUSTOM_SCHEMA_NAMES
 )
+
+if t.TYPE_CHECKING:
+    import jsonschema
 
 
 def set_color_mode(ctx: click.Context, param: str, value: str) -> None:

--- a/src/check_jsonschema/cli/main_command.py
+++ b/src/check_jsonschema/cli/main_command.py
@@ -5,6 +5,7 @@ import textwrap
 import typing as t
 
 import click
+import jsonschema  # noqa: TCH002
 
 from ..catalog import CUSTOM_SCHEMA_NAMES, SCHEMA_CATALOG
 from ..checker import SchemaChecker
@@ -29,9 +30,6 @@ BUILTIN_SCHEMA_NAMES = [f"vendor.{k}" for k in SCHEMA_CATALOG.keys()] + [
 BUILTIN_SCHEMA_CHOICES = (
     BUILTIN_SCHEMA_NAMES + list(SCHEMA_CATALOG.keys()) + CUSTOM_SCHEMA_NAMES
 )
-
-if t.TYPE_CHECKING:
-    import jsonschema
 
 
 def set_color_mode(ctx: click.Context, param: str, value: str) -> None:

--- a/src/check_jsonschema/cli/parse_result.py
+++ b/src/check_jsonschema/cli/parse_result.py
@@ -4,11 +4,14 @@ import enum
 import typing as t
 
 import click
-import jsonschema
 
 from ..formats import FormatOptions
 from ..regex_variants import RegexImplementation, RegexVariantName
-from ..transforms import Transform
+
+if t.TYPE_CHECKING:
+    import jsonschema
+
+    from ..transforms import Transform
 
 
 class SchemaLoadingMode(enum.Enum):

--- a/src/check_jsonschema/cli/warnings.py
+++ b/src/check_jsonschema/cli/warnings.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import typing as t
 import warnings
 
-import click
+if t.TYPE_CHECKING:
+    import click
 
 
 def deprecation_warning_callback(

--- a/src/check_jsonschema/formats/__init__.py
+++ b/src/check_jsonschema/formats/__init__.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import copy
+import typing
 
 import jsonschema
 import jsonschema.validators
 
-from ..regex_variants import RegexImplementation
 from .implementations import validate_rfc3339, validate_time
+
+if typing.TYPE_CHECKING:
+    from ..regex_variants import RegexImplementation
 
 # all known format strings except for a selection from draft3 which have either
 # been renamed or removed:

--- a/src/check_jsonschema/identify_filetype.py
+++ b/src/check_jsonschema/identify_filetype.py
@@ -4,7 +4,10 @@ Identify filetypes by extension
 
 from __future__ import annotations
 
-import pathlib
+import typing
+
+if typing.TYPE_CHECKING:
+    import pathlib
 
 _EXTENSION_MAP = {
     "json": "json",

--- a/src/check_jsonschema/parsers/__init__.py
+++ b/src/check_jsonschema/parsers/__init__.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 import io
-import pathlib
 import typing as t
-
-import ruamel.yaml
 
 from ..identify_filetype import path_to_type
 from . import json5, json_, toml, yaml
+
+if t.TYPE_CHECKING:
+    import pathlib
+
+    import ruamel.yaml
 
 _PARSER_ERRORS: set[type[Exception]] = {
     json_.JSONDecodeError,

--- a/src/check_jsonschema/reporter.py
+++ b/src/check_jsonschema/reporter.py
@@ -13,9 +13,11 @@ import typing as t
 import click
 import jsonschema
 
-from .parsers import ParseError
-from .result import CheckResult
 from .utils import format_error, iter_validation_error
+
+if t.TYPE_CHECKING:
+    from .parsers import ParseError
+    from .result import CheckResult
 
 
 class Reporter(abc.ABC):

--- a/src/check_jsonschema/result.py
+++ b/src/check_jsonschema/result.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
-import pathlib
+import typing
 
-import jsonschema
+if typing.TYPE_CHECKING:
+    import pathlib
 
-from .parsers import ParseError
+    import jsonschema
+
+    from .parsers import ParseError
 
 
 class CheckResult:

--- a/src/check_jsonschema/schema_loader/main.py
+++ b/src/check_jsonschema/schema_loader/main.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import functools
-import pathlib
 import typing as t
 import urllib.error
 import urllib.parse
@@ -11,11 +10,15 @@ import jsonschema
 from ..builtin_schemas import get_builtin_schema
 from ..formats import FormatOptions, format_checker_for_regex_impl, make_format_checker
 from ..parsers import ParserSet
-from ..regex_variants import RegexImplementation
 from ..utils import is_url_ish
 from .errors import UnsupportedUrlScheme
 from .readers import HttpSchemaReader, LocalSchemaReader, StdinSchemaReader
 from .resolver import make_reference_registry
+
+if t.TYPE_CHECKING:
+    import pathlib
+
+    from ..regex_variants import RegexImplementation
 
 
 def _extend_with_default(
@@ -144,7 +147,7 @@ class SchemaLoader(SchemaLoaderBase):
     ) -> jsonschema.protocols.Validator:
         return self._get_validator(format_opts, regex_impl, fill_defaults)
 
-    @functools.lru_cache
+    @functools.lru_cache  # noqa: B019
     def _get_validator(
         self,
         format_opts: FormatOptions,

--- a/src/check_jsonschema/schema_loader/resolver.py
+++ b/src/check_jsonschema/schema_loader/resolver.py
@@ -7,8 +7,10 @@ import referencing
 from referencing.jsonschema import DRAFT202012, Schema
 
 from ..cachedownloader import CacheDownloader
-from ..parsers import ParserSet
 from ..utils import filename2path
+
+if t.TYPE_CHECKING:
+    from ..parsers import ParserSet
 
 
 def make_reference_registry(

--- a/src/check_jsonschema/transforms/__init__.py
+++ b/src/check_jsonschema/transforms/__init__.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import typing
+
 from .azure_pipelines import AZURE_TRANSFORM
-from .base import Transform
 from .gitlab import GITLAB_TRANSFORM
+
+if typing.TYPE_CHECKING:
+    from .base import Transform
 
 TRANSFORM_LIBRARY: dict[str, Transform] = {
     "azure-pipelines": AZURE_TRANSFORM,

--- a/src/check_jsonschema/transforms/__init__.py
+++ b/src/check_jsonschema/transforms/__init__.py
@@ -3,10 +3,8 @@ from __future__ import annotations
 import typing
 
 from .azure_pipelines import AZURE_TRANSFORM
+from .base import Transform  # noqa: TCH001
 from .gitlab import GITLAB_TRANSFORM
-
-if typing.TYPE_CHECKING:
-    from .base import Transform
 
 TRANSFORM_LIBRARY: dict[str, Transform] = {
     "azure-pipelines": AZURE_TRANSFORM,

--- a/src/check_jsonschema/transforms/base.py
+++ b/src/check_jsonschema/transforms/base.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import typing as t
 
-import ruamel.yaml
+if t.TYPE_CHECKING:
+    import ruamel.yaml
 
 
 class Transform:

--- a/src/check_jsonschema/transforms/gitlab.py
+++ b/src/check_jsonschema/transforms/gitlab.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import typing as t
 
-import ruamel.yaml
-
 from .base import Transform
+
+if t.TYPE_CHECKING:
+    import ruamel.yaml
 
 
 class GitLabReferenceExpectationViolation(ValueError):

--- a/src/check_jsonschema/utils.py
+++ b/src/check_jsonschema/utils.py
@@ -11,7 +11,9 @@ import urllib.parse
 import urllib.request
 
 import click
-import jsonschema
+
+if t.TYPE_CHECKING:
+    import jsonschema
 
 WINDOWS = os.name == "nt"
 


### PR DESCRIPTION
### 🧾 Description

This PR replaces `flake8` with [`ruff`](https://github.com/astral-sh/ruff), a fast, modern Python linter that consolidates multiple tools into a single, streamlined solution.

### ✅ Why `ruff`?

- **⚡ Speed**: `ruff` is written in Rust and offers lightning-fast linting — much faster than `flake8`, especially on large codebases.
- **🔧 Tool Consolidation**: `ruff` covers functionality from several other tools, including:
  - `flake8` (plus many of its common plugins)
  - `black` (code formatting)
  - `pyupgrade` (syntax upgrades)
  - `isort` (import sorting)
- **🧩 Consistency**: With one tool managing style, linting, and even formatting, we eliminate potential conflicts and reduce maintenance overhead.
- **🔁 CI Simplification**: Fewer moving parts in the linting pipeline — one config, one command, less to debug.

### 🔄 Changes

- Removed `flake8` and its plugins from dependencies and CI setup.
- Added `ruff` and configured it to match our previous linting behavior.
- Updated development and linting documentation accordingly.

### 📌 Next Steps

- Evaluate enabling `ruff format` to fully replace `black`, allowing a single tool to manage formatting and linting seamlessly.

cc: @sirosen @edgarrmondragon