### PR TITLE
Update Bitbucket Pipelines schema URL

### DIFF
--- a/src/check_jsonschema/catalog.py
+++ b/src/check_jsonschema/catalog.py
@@ -4,7 +4,7 @@ import typing as t
 
 
 def _bitbucket_pipelines_url() -> str:
-    return "https://bitbucket.org/atlassianlabs/intellij-bitbucket-references-plugin/raw/master/src/main/resources/schemas/bitbucket-pipelines.schema.json"  # noqa: E501
+    return "https://api.bitbucket.org/schemas/pipelines-configuration"
 
 
 def _githubusercontent_url(owner: str, repo: str, ref: str, path: str) -> str:


### PR DESCRIPTION
The JSON schema for Bitbucket Pipelines configuration file is now officially provided by Bitbucket.