### PR TITLE
Use calendar.timegm instead of time.mktime for UTC timestamps

### DIFF
--- a/src/check_jsonschema/cachedownloader.py
+++ b/src/check_jsonschema/cachedownloader.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import calendar
 import contextlib
 import hashlib
 import io
@@ -43,7 +44,7 @@ def _resolve_cache_dir(dirname: str) -> str | None:
 
 def _lastmod_from_response(response: requests.Response) -> float:
     try:
-        return time.mktime(
+        return calendar.timegm(
             time.strptime(response.headers["last-modified"], _LASTMOD_FMT)
         )
     # OverflowError: time outside of platform-specific bounds

--- a/tests/unit/test_cachedownloader.py
+++ b/tests/unit/test_cachedownloader.py
@@ -274,10 +274,10 @@ def test_cachedownloader_handles_bad_lastmod_header(
     elif failure_mode == "time_overflow":
         add_default_response()
 
-        def fake_mktime(*args):
+        def fake_timegm(*args):
             raise OverflowError("uh-oh")
 
-        monkeypatch.setattr("time.mktime", fake_mktime)
+        monkeypatch.setattr("calendar.timegm", fake_timegm)
     else:
         raise NotImplementedError
 


### PR DESCRIPTION
time.mktime() converts a time tuple in local time to seconds since the Epoch, as stated in the docs:

> Convert a time tuple in local time to seconds since the Epoch.
> Note that mktime(gmtime(0)) will not generally return zero for most
> time zones; instead the returned value will either be equal to that
> of the timezone or altzone attributes on the time module.

calendar.timegm() is guaranteed to produce UTC timestamp:

> Unrelated but handy function to calculate Unix timestamp from GMT.