### PR TITLE
Fix date format validator to allow non-str objects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,9 @@ Unreleased
 ----------
 
 .. vendor-insert-here
+- Fix a bug in the evaluation of the ``date-time`` format on non-string data,
+  which incorrectly rejected values for which ``string`` was one of several
+  valid types. Thanks :user:`katylava`! (:issue:`571`)
 
 0.33.1
 ------

--- a/src/check_jsonschema/formats/implementations/rfc3339.py
+++ b/src/check_jsonschema/formats/implementations/rfc3339.py
@@ -57,7 +57,7 @@ RFC3339_REGEX = re.compile(
 def validate(date_str: object) -> bool:
     """Validate a string as a RFC3339 date-time."""
     if not isinstance(date_str, str):
-        return False
+        return True
     if not RFC3339_REGEX.match(date_str):
         return False
 

--- a/tests/example-files/explicit-schema/positive/date-format/instance.json
+++ b/tests/example-files/explicit-schema/positive/date-format/instance.json
@@ -1,0 +1,1 @@
+{"some_date": null}

--- a/tests/example-files/explicit-schema/positive/date-format/schema.json
+++ b/tests/example-files/explicit-schema/positive/date-format/schema.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "some_date": {
+            "type": ["string", "null"],
+            "format": "date-time"
+        }
+    },
+    "required": ["some_date"],
+    "additionalProperties": false
+}

--- a/tests/unit/formats/test_rfc3339.py
+++ b/tests/unit/formats/test_rfc3339.py
@@ -22,7 +22,6 @@ def test_simple_positive_cases(datestr):
 @pytest.mark.parametrize(
     "datestr",
     (
-        object(),
         "2018-12-31T23:59:59",
         "2018-12-31T23:59:59+00:00Z",
         "2018-12-31 23:59:59",


### PR DESCRIPTION
Rejecting non-string data results in incorrect rejection of data in
which `string` is one of the available types and the `date-time`
format is in use.

Fixes #571
