### PR TITLE
Bump to the latest version of click-type-test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [dependency-groups]
 dev = [
     "pytest<9",
-    'click-type-test==1.1.0;python_version>="3.10"',
+    'click-type-test==1.3.0;python_version>="3.10"',
     "coverage<8",
     "identify>=2.6.9",
     "pytest-xdist<4",


### PR DESCRIPTION
Needed for compatibility with click v8.3+
