### PR TITLE
Update flake8 plugins & fix lint failures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,9 +32,9 @@ repos:
   hooks:
     - id: flake8
       additional_dependencies:
-        - 'flake8-bugbear==24.12.12'
-        - 'flake8-typing-as-t==1.0.0'
-        - 'flake8-comprehensions==3.16.0'
+        - 'flake8-bugbear==25.11.29'
+        - 'flake8-typing-as-t==1.1.0'
+        - 'flake8-comprehensions==3.17.0'
 - repo: https://github.com/sirosen/slyp
   rev: 0.8.2
   hooks:

--- a/src/check_jsonschema/checker.py
+++ b/src/check_jsonschema/checker.py
@@ -19,6 +19,7 @@ from .schema_loader import SchemaLoaderBase, SchemaParseError, UnsupportedUrlSch
 
 class _Exit(Exception):
     def __init__(self, code: int) -> None:
+        super().__init__(code)
         self.code = code
 
 

--- a/src/check_jsonschema/transforms/gitlab.py
+++ b/src/check_jsonschema/transforms/gitlab.py
@@ -1,17 +1,12 @@
 from __future__ import annotations
 
-import typing as t
-
 import ruamel.yaml
 
 from .base import Transform
 
 
 class GitLabReferenceExpectationViolation(ValueError):
-    def __init__(self, msg: str, data: t.Any) -> None:
-        super().__init__(
-            f"check-jsonschema rejects this gitlab !reference tag: {msg}\n{data!r}"
-        )
+    pass
 
 
 class GitLabReference:
@@ -22,7 +17,10 @@ class GitLabReference:
         cls, constructor: ruamel.yaml.BaseConstructor, node: ruamel.yaml.Node
     ) -> list[str]:
         if not isinstance(node.value, list):
-            raise GitLabReferenceExpectationViolation("non-list value", node)
+            raise GitLabReferenceExpectationViolation(
+                "check-jsonschema rejects this gitlab !reference tag: "
+                f"non-list-value\n{node!r}"
+            )
         return [item.value for item in node.value]
 
 


### PR DESCRIPTION
- Update with `upadup`
- Run `pre-commit run -a`
- Fix the failures on B042 for exceptions which don't play well with copy
