### PR TITLE
Add cleanup to MANIFEST.in to pass check-sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -25,3 +25,10 @@ include justfile
 include scripts/*.py
 include .coveragerc
 include .flake8
+
+
+## Final Cleanup
+# remove files which may be accidentally introduced by `*` and recursive patterns
+
+prune **/__pycache__
+global-exclude *.py[cod]


### PR DESCRIPTION
`check-sdist` with `--inject-junk` now introduces `__pycache__` dirs with
`.py` files in the tests tree, which are then included. To pass, add a
pair of manifest rules to prune all `__pycache__` dirs and any `pyc`,
`pyo`, or `pyd` files.
