### PR TITLE
Resolve nested local refs

### DIFF
--- a/src/check_jsonschema/schema_loader/main.py
+++ b/src/check_jsonschema/schema_loader/main.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import copy
 import functools
 import pathlib
 import typing as t
@@ -133,10 +132,8 @@ class SchemaLoader(SchemaLoaderBase):
     def get_schema(self) -> dict[str, t.Any]:
         data = self.reader.read_schema()
         if self.base_uri is not None:
-            data = copy.copy(data)
             data["$id"] = self.base_uri
         elif "$id" not in data and (retrieval_uri := self.get_schema_retrieval_uri()):
-            data = copy.copy(data)
             data["$id"] = retrieval_uri
         return data
 

--- a/src/check_jsonschema/schema_loader/main.py
+++ b/src/check_jsonschema/schema_loader/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import functools
 import pathlib
 import typing as t
@@ -132,7 +133,11 @@ class SchemaLoader(SchemaLoaderBase):
     def get_schema(self) -> dict[str, t.Any]:
         data = self.reader.read_schema()
         if self.base_uri is not None:
+            data = copy.copy(data)
             data["$id"] = self.base_uri
+        elif "$id" not in data and (retrieval_uri := self.get_schema_retrieval_uri()):
+            data = copy.copy(data)
+            data["$id"] = retrieval_uri
         return data
 
     def get_validator(

--- a/tests/acceptance/test_local_relative_ref.py
+++ b/tests/acceptance/test_local_relative_ref.py
@@ -30,6 +30,39 @@ CASE2_PASSING_DOCUMENT = {"test": "some data"}
 CASE2_FAILING_DOCUMENT = {"test": {"foo": "bar"}}
 
 
+NESTED_REF_MAIN_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "type": "object",
+    "properties": {
+        "pupils": {
+            "type": "array",
+            "items": {"$ref": "../person/person.schema.json"},
+        }
+    },
+}
+NESTED_REF_PERSON_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "address": {"$ref": "../address/address.schema.json"},
+    },
+}
+NESTED_REF_ADDRESS_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "street": {"type": "string"},
+    },
+}
+NESTED_REF_PASSING_DOCUMENT = {
+    "pupils": [
+        {
+            "name": "Alice Smith",
+            "address": {"street": "123 Main St"},
+        }
+    ],
+}
+
+
 def _prep_files(tmp_path, main_schema, other_schema_data, instance):
     main_schemafile = tmp_path / "main_schema.json"
     main_schemafile.write_text(json.dumps(main_schema))
@@ -113,3 +146,29 @@ def test_local_ref_schema_failure_case(
     assert res.exit_code == 1
     if expect_err is not None:
         assert expect_err in res.stdout
+
+
+@pytest.mark.parametrize("with_file_scheme", [True, False])
+def test_local_nested_ref_schema(run_line_simple, tmp_path, with_file_scheme):
+    schema_dir = tmp_path / "schema"
+    school_dir = schema_dir / "school"
+    person_dir = schema_dir / "person"
+    address_dir = schema_dir / "address"
+    school_dir.mkdir(parents=True)
+    person_dir.mkdir()
+    address_dir.mkdir()
+
+    main_schemafile = school_dir / "school.schema.json"
+    main_schemafile.write_text(json.dumps(NESTED_REF_MAIN_SCHEMA))
+    (person_dir / "person.schema.json").write_text(json.dumps(NESTED_REF_PERSON_SCHEMA))
+    (address_dir / "address.schema.json").write_text(
+        json.dumps(NESTED_REF_ADDRESS_SCHEMA)
+    )
+    doc = tmp_path / "doc.json"
+    doc.write_text(json.dumps(NESTED_REF_PASSING_DOCUMENT))
+
+    if with_file_scheme:
+        schemafile = main_schemafile.resolve().as_uri()
+    else:
+        schemafile = str(main_schemafile)
+    run_line_simple(["--schemafile", schemafile, str(doc)])

--- a/tests/acceptance/test_local_relative_ref.py
+++ b/tests/acceptance/test_local_relative_ref.py
@@ -36,7 +36,7 @@ NESTED_REF_MAIN_SCHEMA = {
     "properties": {
         "pupils": {
             "type": "array",
-            "items": {"$ref": "../person/person.schema.json"},
+            "items": {"$ref": "../shared/person/person.schema.json"},
         }
     },
 }
@@ -58,6 +58,14 @@ NESTED_REF_PASSING_DOCUMENT = {
         {
             "name": "Alice Smith",
             "address": {"street": "123 Main St"},
+        }
+    ],
+}
+NESTED_REF_FAILING_DOCUMENT = {
+    "pupils": [
+        {
+            "name": "Alice Smith",
+            "address": {"street": 123},
         }
     ],
 }
@@ -152,10 +160,10 @@ def test_local_ref_schema_failure_case(
 def test_local_nested_ref_schema(run_line_simple, tmp_path, with_file_scheme):
     schema_dir = tmp_path / "schema"
     school_dir = schema_dir / "school"
-    person_dir = schema_dir / "person"
-    address_dir = schema_dir / "address"
+    person_dir = schema_dir / "shared" / "person"
+    address_dir = schema_dir / "shared" / "address"
     school_dir.mkdir(parents=True)
-    person_dir.mkdir()
+    person_dir.mkdir(parents=True)
     address_dir.mkdir()
 
     main_schemafile = school_dir / "school.schema.json"
@@ -172,3 +180,32 @@ def test_local_nested_ref_schema(run_line_simple, tmp_path, with_file_scheme):
     else:
         schemafile = str(main_schemafile)
     run_line_simple(["--schemafile", schemafile, str(doc)])
+
+
+@pytest.mark.parametrize("with_file_scheme", [True, False])
+def test_local_nested_ref_schema_failure(run_line, tmp_path, with_file_scheme):
+    schema_dir = tmp_path / "schema"
+    school_dir = schema_dir / "school"
+    person_dir = schema_dir / "shared" / "person"
+    address_dir = schema_dir / "shared" / "address"
+    school_dir.mkdir(parents=True)
+    person_dir.mkdir(parents=True)
+    address_dir.mkdir()
+
+    main_schemafile = school_dir / "school.schema.json"
+    main_schemafile.write_text(json.dumps(NESTED_REF_MAIN_SCHEMA))
+    (person_dir / "person.schema.json").write_text(json.dumps(NESTED_REF_PERSON_SCHEMA))
+    (address_dir / "address.schema.json").write_text(
+        json.dumps(NESTED_REF_ADDRESS_SCHEMA)
+    )
+    doc = tmp_path / "doc.json"
+    doc.write_text(json.dumps(NESTED_REF_FAILING_DOCUMENT))
+
+    if with_file_scheme:
+        schemafile = main_schemafile.resolve().as_uri()
+    else:
+        schemafile = str(main_schemafile)
+
+    res = run_line(["check-jsonschema", "--schemafile", schemafile, str(doc)])
+    assert res.exit_code == 1
+    assert "123 is not of type 'string'" in res.stdout


### PR DESCRIPTION
Fixes #640.

Local schemas without an explicit `$id` were not using their retrieval URI as the base URI. This could break nested relative `$ref`s, because references in loaded schemas were resolved from the wrong directory.

This sets the retrieval URI as the internal base for local schemas without `$id`, and adds a regression test for nested local references.

Tested with:

```text
python -m pytest tests/acceptance/test_local_relative_ref.py -q
```