### PR TITLE
Apply timeout-minutes GHA enforcement

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,6 +14,7 @@ jobs:
             py: "3.10"
 
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     name: "'${{ matrix.toxenv }}' on py${{ matrix.py }}"
     steps:
       - uses: actions/checkout@v7
@@ -39,6 +40,7 @@ jobs:
   # run tests after building an sdist and unpacking it
   test-sdist:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
@@ -65,6 +67,7 @@ jobs:
         py: ['3.10', '3.11', '3.12', '3.13', '3.14']
     name: "Test on ${{ matrix.os }}, py${{ matrix.py }}"
     runs-on: "${{ matrix.os }}-latest"
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
 
@@ -108,6 +111,7 @@ jobs:
   collate-tests:
     needs: [ci-test-matrix]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     name: "Collate results to check for skipped tests"
     steps:
       - uses: actions/checkout@v7
@@ -127,6 +131,7 @@ jobs:
   # "Adding new hooks"
   ensure-catalog-matches-hook-config:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
 
@@ -156,6 +161,7 @@ jobs:
   self-check:
     name: "Self-Check"
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   vendor-schemas:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
     - uses: actions/checkout@v7
     - uses: actions/setup-python@v7

--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -7,6 +7,7 @@ on:
 jobs:
   build-dists:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@v7
@@ -30,6 +31,7 @@ jobs:
   publish_pypi:
     needs: [build-dists]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     environment: publish
     permissions:
       id-token: write
@@ -46,6 +48,7 @@ jobs:
   publish_release_asset:
     needs: [build-dists]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - uses: actions/download-artifact@v8

--- a/.github/workflows/publish_to_test_pypi.yaml
+++ b/.github/workflows/publish_to_test_pypi.yaml
@@ -14,6 +14,7 @@ on:
 jobs:
   build-dists:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@v7
@@ -46,6 +47,7 @@ jobs:
   publish:
     needs: [build-dists]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     environment: publish-testpypi
     permissions:
       id-token: write

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,11 @@
 repos:
 # dogfood
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.37.4
+  rev: 0.38.0
   hooks:
     - id: check-dependabot
     - id: check-github-workflows
+    - id: check-github-workflows-require-timeout
     - id: check-readthedocs
     - id: check-metaschema
       name: Validate Vendored Schemas


### PR DESCRIPTION
Update the dogfooding pre-commit config and use the new GHA custom
schema hook. Update workflows to pass.
